### PR TITLE
Add option for changing the quality and size of the screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.0]
+
+- Add option for changing the quality and size of the screenshot
+
 ## [1.1.0]
 
 - Fix Flutter Web (#13, #50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [1.2.0]
 
-- Add option for changing the quality and size of the screenshot
+- Add option for changing the quality and size of the screenshot (`BetterFeedback.pixelRatio`)
 
 ## [1.1.0]
 

--- a/lib/src/better_feedback.dart
+++ b/lib/src/better_feedback.dart
@@ -18,7 +18,11 @@ class BetterFeedback extends StatefulWidget {
     this.localeOverride,
     this.mode = FeedbackMode.navigate,
     this.pixelRatio = 3.0,
-  }) : super(key: key);
+  })  : assert(
+          pixelRatio > 0,
+          'pixelRatio needs to be larger than 0',
+        ),
+        super(key: key);
 
   /// The application to wrap, typically a [MaterialApp].
   final Widget child;

--- a/lib/src/better_feedback.dart
+++ b/lib/src/better_feedback.dart
@@ -53,6 +53,7 @@ class BetterFeedback extends StatefulWidget {
   /// Specifying 1.0 will give you a 1:1 mapping between
   /// logical pixels and the output pixels in the image.
   /// The default is a pixel ration of 3 and a value below 1 is not recommended.
+  ///
   /// See [RenderRepaintBoundary](https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html)
   /// for the underlying implementation.
   final double pixelRatio;

--- a/lib/src/better_feedback.dart
+++ b/lib/src/better_feedback.dart
@@ -17,6 +17,7 @@ class BetterFeedback extends StatefulWidget {
     this.localizationsDelegates,
     this.localeOverride,
     this.mode = FeedbackMode.navigate,
+    this.pixelRatio = 3.0,
   }) : super(key: key);
 
   /// The application to wrap, typically a [MaterialApp].
@@ -42,6 +43,11 @@ class BetterFeedback extends StatefulWidget {
   /// By default it will allow the user to navigate.
   /// See [FeedbackMode] for other options.
   final FeedbackMode mode;
+
+  /// Set the quality and size of the screenshot
+  /// Default is 3.0 for high resolution
+  /// A ratio below 1.0 is not recommended
+  final double pixelRatio;
 
   /// Call `BetterFeedback.of(context)` to get an instance of
   /// [FeedbackData] on which you can call `.show()` or `.hide()`
@@ -87,6 +93,7 @@ class _BetterFeedbackState extends State<BetterFeedback> {
                 isFeedbackVisible: feedbackVisible,
                 drawColors: FeedbackTheme.of(context).drawColors,
                 mode: widget.mode,
+                pixelRatio: widget.pixelRatio,
               );
             },
           ),

--- a/lib/src/better_feedback.dart
+++ b/lib/src/better_feedback.dart
@@ -48,9 +48,13 @@ class BetterFeedback extends StatefulWidget {
   /// See [FeedbackMode] for other options.
   final FeedbackMode mode;
 
-  /// Set the quality and size of the screenshot
-  /// Default is 3.0 for high resolution
-  /// A ratio below 1.0 is not recommended
+  /// The pixelRatio describes the scale between
+  /// the logical pixels and the size of the output image.
+  /// Specifying 1.0 will give you a 1:1 mapping between
+  /// logical pixels and the output pixels in the image.
+  /// The default is a pixel ration of 3 and a value below 1 is not recommended.
+  /// See [RenderRepaintBoundary](https://api.flutter.dev/flutter/rendering/RenderRepaintBoundary/toImage.html)
+  /// for the underlying implementation.
   final double pixelRatio;
 
   /// Call `BetterFeedback.of(context)` to get an instance of

--- a/lib/src/feedback_widget.dart
+++ b/lib/src/feedback_widget.dart
@@ -20,8 +20,8 @@ class FeedbackWidget extends StatefulWidget {
     required this.isFeedbackVisible,
     required this.drawColors,
     required this.mode,
-    this.pixelRatio = 3.0,
-  })  : assert(
+    required this.pixelRatio,
+  })   : assert(
           // This way, we can have a const constructor
           // ignore: prefer_is_empty
           drawColors.length > 0,
@@ -186,7 +186,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
                           FeedbackData.of(context)!.onFeedback!,
                           screenshotController,
                           feedback,
-                          pixelRatio: widget.pixelRatio,
+                          widget.pixelRatio,
                         );
                         painterController.clear();
                       },
@@ -205,9 +205,9 @@ class FeedbackWidgetState extends State<FeedbackWidget>
   static Future<void> sendFeedback(
     OnFeedbackCallback onFeedbackSubmitted,
     ScreenshotController controller,
-    String feedbackText, {
+    String feedbackText,
+    double pixelRatio, {
     Duration delay = const Duration(milliseconds: 200),
-    double pixelRatio = 3.0,
   }) async {
     // Wait for the keyboard to be closed, and then proceed
     // to take a screenshot
@@ -234,10 +234,10 @@ class FeedbackWidgetState extends State<FeedbackWidget>
     BuildContext context,
     OnFeedbackCallback onFeedbackSubmitted,
     ScreenshotController controller,
-    String feedbackText, {
+    String feedbackText,
+    double pixelRatio, {
     Duration delay = const Duration(milliseconds: 200),
     bool showKeyboard = false,
-    double pixelRatio = 3.0,
   }) async {
     if (!showKeyboard) {
       _hideKeyboard(context);
@@ -246,8 +246,8 @@ class FeedbackWidgetState extends State<FeedbackWidget>
       onFeedbackSubmitted,
       controller,
       feedbackText,
+      pixelRatio,
       delay: delay,
-      pixelRatio: pixelRatio,
     );
 
     // Close feedback mode

--- a/lib/src/feedback_widget.dart
+++ b/lib/src/feedback_widget.dart
@@ -20,7 +20,8 @@ class FeedbackWidget extends StatefulWidget {
     required this.isFeedbackVisible,
     required this.drawColors,
     required this.mode,
-  })   : assert(
+    this.pixelRatio = 3.0,
+  })  : assert(
           // This way, we can have a const constructor
           // ignore: prefer_is_empty
           drawColors.length > 0,
@@ -30,6 +31,7 @@ class FeedbackWidget extends StatefulWidget {
 
   final bool isFeedbackVisible;
   final FeedbackMode mode;
+  final double pixelRatio;
   final Widget child;
   final List<Color> drawColors;
 
@@ -184,6 +186,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
                           FeedbackData.of(context)!.onFeedback!,
                           screenshotController,
                           feedback,
+                          pixelRatio: widget.pixelRatio,
                         );
                         painterController.clear();
                       },
@@ -204,6 +207,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
     ScreenshotController controller,
     String feedbackText, {
     Duration delay = const Duration(milliseconds: 200),
+    double pixelRatio = 3.0,
   }) async {
     // Wait for the keyboard to be closed, and then proceed
     // to take a screenshot
@@ -212,7 +216,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
       () async {
         // Take high resolution screenshot
         final screenshot = await controller.capture(
-          pixelRatio: 3,
+          pixelRatio: pixelRatio,
           delay: const Duration(milliseconds: 0),
         );
 
@@ -233,6 +237,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
     String feedbackText, {
     Duration delay = const Duration(milliseconds: 200),
     bool showKeyboard = false,
+    double pixelRatio = 3.0,
   }) async {
     if (!showKeyboard) {
       _hideKeyboard(context);
@@ -242,6 +247,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
       controller,
       feedbackText,
       delay: delay,
+      pixelRatio: pixelRatio,
     );
 
     // Close feedback mode

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: feedback
 description: A Flutter package for getting better feedback. It allows the user to give interactive feedback directly in the app.
-version: 1.1.0
+version: 1.2.0
 homepage: https://uekoetter.dev/
 repository: https://github.com/ueman/feedback
 issue_tracker: https://github.com/ueman/feedback/issues

--- a/test/feedback_test.dart
+++ b/test/feedback_test.dart
@@ -123,7 +123,7 @@ void main() {
     }, skip: true);
   });
 
-  test('feedback sendFeedback with default settings', () async {
+  test('feedback sendFeedback with high resolution', () async {
     var callbackWasCalled = false;
     final screenshotController = MockScreenshotController();
     void onFeedback(
@@ -139,6 +139,7 @@ void main() {
       onFeedback,
       screenshotController,
       'Hello World!',
+      3,
       delay: const Duration(seconds: 0),
     );
     expect(callbackWasCalled, true);
@@ -160,8 +161,8 @@ void main() {
       onFeedback,
       screenshotController,
       'Hello World!',
+      1,
       delay: const Duration(seconds: 0),
-      pixelRatio: 1,
     );
     expect(callbackWasCalled, true);
   });

--- a/test/feedback_test.dart
+++ b/test/feedback_test.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:feedback/feedback.dart';
@@ -122,7 +123,7 @@ void main() {
     }, skip: true);
   });
 
-  test('feedback sendFeedback', () async {
+  test('feedback sendFeedback with default settings', () async {
     var callbackWasCalled = false;
     final screenshotController = MockScreenshotController();
     void onFeedback(
@@ -130,7 +131,7 @@ void main() {
       Uint8List? feedbackScreenshot,
     ) {
       expect(feedback, 'Hello World!');
-      expect(feedbackScreenshot, Uint8List.fromList([1, 1, 1, 1]));
+      expect(feedbackScreenshot?.length, 64);
       callbackWasCalled = true;
     }
 
@@ -142,6 +143,28 @@ void main() {
     );
     expect(callbackWasCalled, true);
   });
+
+  test('feedback sendFeedback with low resolution', () async {
+    var callbackWasCalled = false;
+    final screenshotController = MockScreenshotController();
+    void onFeedback(
+      String feedback,
+      Uint8List? feedbackScreenshot,
+    ) {
+      expect(feedback, 'Hello World!');
+      expect(feedbackScreenshot?.length, 4);
+      callbackWasCalled = true;
+    }
+
+    await FeedbackWidgetState.sendFeedback(
+      onFeedback,
+      screenshotController,
+      'Hello World!',
+      delay: const Duration(seconds: 0),
+      pixelRatio: 1,
+    );
+    expect(callbackWasCalled, true);
+  });
 }
 
 class MockScreenshotController implements ScreenshotController {
@@ -149,7 +172,9 @@ class MockScreenshotController implements ScreenshotController {
   Future<Uint8List> capture(
       {double pixelRatio = 1,
       Duration delay = const Duration(milliseconds: 20)}) {
-    return Future.value(Uint8List.fromList([1, 1, 1, 1]));
+    return Future.value(Uint8List.fromList(
+      List.generate(pow(4, pixelRatio).ceil(), (number) => 1),
+    ));
   }
 }
 


### PR DESCRIPTION
## :scroll: Description
Exposes the pixelRatio parameter, so that the user can influence the quality and size of the screenshot. Default stays the same (3.0).


## :bulb: Motivation and Context
The quality and size depends on the app. For an upload to online storage the high resolution results in too large files (2MB+). This would mean that a conversion would be needed, which is costly on the server. Instead it makes more sense to allow to take the screenshot at a lower resolution right away.


## :green_heart: How did you test it?
Integration Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] I updated the docs if needed
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
