### PR TITLE
Enter-Button dismisses keyboard

### DIFF
--- a/lib/src/feedback_bottom_sheet.dart
+++ b/lib/src/feedback_bottom_sheet.dart
@@ -73,6 +73,7 @@ class __FeedbackBottomSheetState extends State<_FeedbackBottomSheet> {
                     maxLines: 2,
                     minLines: 2,
                     controller: controller,
+                    textInputAction: TextInputAction.done,
                   ),
                 ),
                 TextButton(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
By default, pressing 'Enter', will now dismiss the keyboard.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better user experience.

## :green_heart: How did you test it?
Tested on real iOS Device (iPhone SE 2020)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
