### PR TITLE
Make Currently Selected Column Control Use accentColor

### DIFF
--- a/lib/src/controls_column.dart
+++ b/lib/src/controls_column.dart
@@ -1,5 +1,6 @@
 import 'package:feedback/src/feedback_mode.dart';
 import 'package:feedback/src/l18n/translation.dart';
+import 'package:feedback/src/theme/feedback_theme.dart';
 import 'package:flutter/material.dart';
 
 /// This is the Widget on the right side of the app when the feedback view
@@ -60,7 +61,8 @@ class ControlsColumn extends StatelessWidget {
               onPressed: isNavigatingActive
                   ? null
                   : () => onControlModeChanged(FeedbackMode.navigate),
-              disabledTextColor: Theme.of(context).accentColor,
+              disabledTextColor:
+                  FeedbackTheme.of(context).activeFeedbackModeColor,
             ),
           ),
           _ColumnDivider(),
@@ -73,7 +75,8 @@ class ControlsColumn extends StatelessWidget {
               onPressed: isNavigatingActive
                   ? () => onControlModeChanged(FeedbackMode.draw)
                   : null,
-              disabledTextColor: Theme.of(context).accentColor,
+              disabledTextColor:
+                  FeedbackTheme.of(context).activeFeedbackModeColor,
             ),
           ),
           IconButton(

--- a/lib/src/controls_column.dart
+++ b/lib/src/controls_column.dart
@@ -60,6 +60,7 @@ class ControlsColumn extends StatelessWidget {
               onPressed: isNavigatingActive
                   ? null
                   : () => onControlModeChanged(FeedbackMode.navigate),
+              disabledTextColor: Theme.of(context).accentColor,
             ),
           ),
           _ColumnDivider(),
@@ -72,6 +73,7 @@ class ControlsColumn extends StatelessWidget {
               onPressed: isNavigatingActive
                   ? () => onControlModeChanged(FeedbackMode.draw)
                   : null,
+              disabledTextColor: Theme.of(context).accentColor,
             ),
           ),
           IconButton(

--- a/lib/src/theme/feedback_theme.dart
+++ b/lib/src/theme/feedback_theme.dart
@@ -13,6 +13,10 @@ const _defaultDrawColors = [
 /// or the default value of ThemeData.canvasColor
 const _lightGrey = Color(0xFFFAFAFA);
 
+/// This is the same as `Colors.blue`
+/// or the default value of ThemeData.accentColor
+const _blue = Color(0xFF2196F3);
+
 const _defaultBottomSheetDescriptionStyle = TextStyle(
   color: Colors.black,
 );
@@ -23,6 +27,7 @@ class FeedbackThemeData {
   FeedbackThemeData({
     this.background = Colors.grey,
     this.feedbackSheetColor = _lightGrey,
+    this.activeFeedbackModeColor = _blue,
     this.drawColors = _defaultDrawColors,
     this.bottomSheetDescriptionStyle = _defaultBottomSheetDescriptionStyle,
   }) :
@@ -38,8 +43,11 @@ class FeedbackThemeData {
   final Color background;
 
   /// The background color of the bottomsheet in which the user can input
-  /// his feedback and thougts.
+  /// his feedback and thoughts.
   final Color feedbackSheetColor;
+
+  /// The color to highlight the currently selected feedback mode.
+  final Color activeFeedbackModeColor;
 
   /// Colors which can be used to draw while in feedback mode.
   final List<Color> drawColors;


### PR DESCRIPTION
## :scroll: Description
Uses `disabledColor` to make the currently selected navigate/draw button highlighted with a color specified in `FeedbackTheme`.


## :bulb: Motivation and Context
See: https://github.com/ueman/feedback/issues/75


## :green_heart: How did you test it?
Ran the example app (this is a super small/safe change so hopefully that's sufficient?)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
1. Review, merge and publish!
2. Consider extending the feedback theme to allow users to override this color directly.