### PR TITLE
Fixed 'feedback callback gets called' Test

### DIFF
--- a/lib/src/feedback_bottom_sheet.dart
+++ b/lib/src/feedback_bottom_sheet.dart
@@ -70,6 +70,7 @@ class __FeedbackBottomSheetState extends State<_FeedbackBottomSheet> {
                 ),
                 Material(
                   child: TextField(
+                    key: const Key('text_input_field'),
                     maxLines: 2,
                     minLines: 2,
                     controller: controller,

--- a/test/feedback_test.dart
+++ b/test/feedback_test.dart
@@ -138,8 +138,7 @@ void main() {
           find.byKey(const Key('submit_feedback_button'));
 
       await tester.tap(submitFeedbackButton);
-      // pump for 200 milliseconds to wait for keyboard to hide on submit
-      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      await tester.pumpAndSettle();
 
       expect(submittedText, 'This app is lame, 2/10.');
       expect(submittedScreenshot, isNotNull);

--- a/test/test_app.dart
+++ b/test/test_app.dart
@@ -13,7 +13,10 @@ class MyTestApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const MyTestPage(title: 'Feedback Test Page'),
+      home: MyTestPage(
+        title: 'Feedback Test Page',
+        onFeedback: onFeedback,
+      ),
     );
   }
 }


### PR DESCRIPTION
## :scroll: Description
Got distracted trying to fix the `feedback callback gets called` test while working on #78. Finally fixed it and figured I'd put the fix in a PR to go in before #78 given that the latter is huge and controversial and thus may not even go in.

There were three primary aspects to fixing the test:

1. It needed to be restructured so that it fails if the callback isn't called-previously it'd only fail if the callback WAS called, but with a null screenshot.
2. Screenshot was creating some weird asynchronous dependency that I couldn't understand. But whatever it was it was causing `await controller.capture...` to hang in the testing environment so I swapped it out with the mock screenshot controller.
3. The test app was accidentally always passing a null `onFeedback` to `MyTestPage`.



## :bulb: Motivation and Context
Test was broken. Didn't want the test to be broken.


## :green_heart: How did you test it?
I ran the test with intentionally failing output to verify it fails when it should, then ran it normally and verified that it succeeded.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Merge-a-rooni! @ueman 