### PR TITLE
Add intelligent handling of the back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.0]
+
+- The back button now [intelligently](https://github.com/ueman/feedback/issues/116) reverses drawings and closes the drawing mode
+
 ## [2.0.0]
 
 THIS IS A BREAKING CHANGE

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.6.1"
+  back_button_interceptor:
+    dependency: transitive
+    description:
+      name: back_button_interceptor
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -70,7 +77,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
   ffi:
     dependency: transitive
     description:

--- a/lib/src/feedback_widget.dart
+++ b/lib/src/feedback_widget.dart
@@ -10,6 +10,7 @@ import 'package:feedback/src/screenshot.dart';
 import 'package:feedback/src/theme/feedback_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
+import 'package:back_button_interceptor/back_button_interceptor.dart';
 
 typedef FeedbackButtonPress = void Function(BuildContext context);
 
@@ -45,7 +46,9 @@ class FeedbackWidget extends StatefulWidget {
 @visibleForTesting
 class FeedbackWidgetState extends State<FeedbackWidget>
     with SingleTickerProviderStateMixin {
+  @visibleForTesting
   late PainterController painterController = create();
+
   ScreenshotController screenshotController = ScreenshotController();
   TextEditingController textEditingController = TextEditingController();
 
@@ -64,9 +67,30 @@ class FeedbackWidgetState extends State<FeedbackWidget>
   }
 
   @override
+  void initState() {
+    super.initState();
+    BackButtonInterceptor.add(backButtonIntercept);
+  }
+
+  @override
   void dispose() {
     super.dispose();
     _controller.dispose();
+    BackButtonInterceptor.remove(backButtonIntercept);
+  }
+
+  @internal
+  @visibleForTesting
+  bool backButtonIntercept(bool stopDefaultButtonEvent, RouteInfo info) {
+    if (mode == FeedbackMode.draw && widget.isFeedbackVisible) {
+      if (painterController.getStepCount() > 0) {
+        painterController.undo();
+      } else {
+        BetterFeedback.of(context).hide();
+      }
+      return true;
+    }
+    return false;
   }
 
   @override

--- a/lib/src/painter.dart
+++ b/lib/src/painter.dart
@@ -164,4 +164,13 @@ class PainterController extends ChangeNotifier {
     _pathHistory.clear();
     notifyListeners();
   }
+
+  int getStepCount() {
+    return _pathHistory._paths.length;
+  }
+
+  @visibleForTesting
+  void addMockStep() {
+    _pathHistory._paths.add(MapEntry<Path, Paint>(Path(), Paint()));
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: feedback
 description: A Flutter package for getting better feedback. It allows the user to give interactive feedback directly in the app.
-version: 2.0.0
+version: 2.1.0
 homepage: https://uekoetter.dev/
 repository: https://github.com/ueman/feedback
 issue_tracker: https://github.com/ueman/feedback/issues
@@ -10,6 +10,7 @@ environment:
   flutter: '>=2.0.0'
 
 dependencies:
+  back_button_interceptor: ^5.0.1
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
## :scroll: Description
Implements https://github.com/ueman/feedback/issues/116

The behavior of the back button in navigation mode remains the same.
In drawing mode, it will first undo the last drawings.
If no drawing is left, the feedback view is closed.

I wanted to implement the listener to the back button with WillPopScope, but this requires a Scaffold.
I was unable to find any other way to listen to the back button without using a new dependency.
However [this dependency](https://pub.dev/packages/back_button_interceptor) is well-maintained, compatible to the same scope as this package currently is and light-weight.

## :bulb: Motivation and Context
See https://github.com/ueman/feedback/issues/116

## :green_heart: How did you test it?
Android Emulator, Test cases

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
None