### PR TITLE
Dispose TextField controller and unfocus feature

### DIFF
--- a/lib/src/feedback_builder/string_feedback.dart
+++ b/lib/src/feedback_builder/string_feedback.dart
@@ -32,37 +32,46 @@ class _StringFeedbackState extends State<StringFeedback> {
   }
 
   @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Expanded(
-          child: ListView(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-            children: <Widget>[
-              Text(
-                FeedbackLocalizations.of(context).feedbackDescriptionText,
-                maxLines: 2,
-                style: FeedbackTheme.of(context).bottomSheetDescriptionStyle,
-              ),
-              TextField(
-                key: const Key('text_input_field'),
-                maxLines: 2,
-                minLines: 2,
-                controller: controller,
-                textInputAction: TextInputAction.done,
-              ),
-            ],
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: Column(
+        children: <Widget>[
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+              children: <Widget>[
+                Text(
+                  FeedbackLocalizations.of(context).feedbackDescriptionText,
+                  maxLines: 2,
+                  style: FeedbackTheme.of(context).bottomSheetDescriptionStyle,
+                ),
+                TextField(
+                  key: const Key('text_input_field'),
+                  maxLines: 2,
+                  minLines: 2,
+                  controller: controller,
+                  textInputAction: TextInputAction.done,
+                ),
+              ],
+            ),
           ),
-        ),
-        TextButton(
-          key: const Key('submit_feedback_button'),
-          child: Text(
-            FeedbackLocalizations.of(context).submitButtonText,
+          TextButton(
+            key: const Key('submit_feedback_button'),
+            child: Text(
+              FeedbackLocalizations.of(context).submitButtonText,
+            ),
+            onPressed: () => widget.onSubmit(controller.text),
           ),
-          onPressed: () => widget.onSubmit(controller.text),
-        ),
-        const SizedBox(height: 8),
-      ],
+          const SizedBox(height: 8),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## :scroll: Description
This PR disposes the TextField's controller and unfocus it when user taps outside of the field (but inside the bottom sheet).


## :bulb: Motivation and Context
There's no way to unfocus the TextField

## :green_heart: How did you test it?
Tap on the text field, tap outside of it but inside bottom sheet

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
