### PR TITLE
Added devcontainer including documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "image": "cirrusci/flutter:latest",
+    "forwardPorts": [3000]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Via GitHub Codespaces
+
+The easiest way to get started contributing to this project is [by creating a new codespace](https://docs.github.com/en/codespaces/getting-started/quickstart#creating-your-codespace).
+
+After your codespace is ready, open a new integrated terminal and go to the example project:
+
+```
+cd ./feedback/example
+```
+
+Then download all dependencies and start the flutter web server:
+
+```
+flutter run -d web-server --web-hostname=0.0.0.0 --web-port=3000
+```
+
+> **Note:** A popup will show up in the lower right corner notifying you that your application is ready and running on port 3000. **The "Open in browser" link will only work _after_ the compilation has succeeded!** 
+> 
+> When you see an error page, wait until the compilation succeeds and refresh the browser tab. Otherwise you may need to go to the "PORTS" menu next to the VS Code terminal and click on the little browser icon that appears next to the local address when you hover over the entry for port 3000.
+
+Changes in the library or the example applications are reflected after hot restarting and reloading the browser tab.


### PR DESCRIPTION
## :scroll: Description
This adds support for GitHub codespaces using the `cirrusci:flutter` docker image.


<img width="1439" alt="Screen Shot 2021-10-29 at 20 01 46" src="https://user-images.githubusercontent.com/10284694/139481541-e50349fd-887b-4b53-9dd9-4bf98b03e16e.png">

## :bulb: Motivation and Context
This eases contributing to this library. Contributors do not need to setup a whole flutter toolchain + emulators locally.


## :green_heart: How did you test it?
I created this PR from the codespace created by this PR.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [  ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Test it for yourself (Open a new code space, copy over the `devcontainer.json` file, rebuild the code space, follow the instructions in `CONTRIBUTING.md`)
