### PR TITLE
Fix typo in debugPrint

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -125,7 +125,7 @@ class GlobalFeedbackLocalizationsDelegate
     }
     debugPrint(
       'The locale $locale is not supported, '
-      'falling back to englisch translations',
+      'falling back to english translations',
     );
     return true;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The locale debugPrint says `englisch` although it should be `english`.
thanks @calcitem for finding this

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We just saw the german english string in our app and pinned it down to this package

## :green_heart: How did you test it?

compile, get an unsupported locale, see the log :upside_down_face: 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
<s>I added tests to verify changes </s> N.A.
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
