### PR TITLE
Keep the initial mode after we re-open the widget

### DIFF
--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -100,6 +100,8 @@ class FeedbackWidgetState extends State<FeedbackWidget>
   @override
   void didUpdateWidget(FeedbackWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
+    // update feedback mode with the initial value
+    mode = widget.mode;
     if (oldWidget.isFeedbackVisible != widget.isFeedbackVisible &&
         oldWidget.isFeedbackVisible == false) {
       // Feedback is now visible,

--- a/feedback/test/feedback_test.dart
+++ b/feedback/test/feedback_test.dart
@@ -314,6 +314,44 @@ void main() {
     });
   });
 
+  testWidgets(
+      'check if the initial mode persists after re-open the feedback widget',
+      (tester) async {
+    const widget = BetterFeedback(
+      mode: FeedbackMode.navigate,
+      child: MyTestApp(),
+    );
+
+    await tester.pumpWidget(widget);
+    await tester.pumpAndSettle();
+
+    final feedbackWidgetState =
+        tester.state<FeedbackWidgetState>(find.byType(FeedbackWidget));
+
+    expect(feedbackWidgetState.mode, FeedbackMode.navigate);
+
+    // open feedback
+    final openFeedbackButton = find.byKey(const Key('open_feedback'));
+    await tester.tap(openFeedbackButton);
+    await tester.pumpAndSettle();
+
+    // change the mode to `draw` mode
+    final drawButton = find.byKey(const ValueKey<String>('draw_button'));
+    await tester.tap(drawButton);
+
+    expect(feedbackWidgetState.mode, FeedbackMode.draw);
+
+    // close feedback
+    feedbackWidgetState.backButtonIntercept();
+
+    // open feedback
+    await tester.tap(openFeedbackButton);
+    await tester.pumpAndSettle();
+
+    // verify the initial mode
+    expect(feedbackWidgetState.mode, FeedbackMode.navigate);
+  });
+
   test('feedback sendFeedback with high resolution', () async {
     var callbackWasCalled = false;
     final screenshotController = MockScreenshotController();


### PR DESCRIPTION
## :scroll: Description
This change keeps the initial model after we re-open the feedback widget.


## :bulb: Motivation and Context
When we select an initial mode, let say `Navigation`, every time we open the feedback widget that mode should be selected but it wasn't working in that way, the last mode selected remains even after we re-open the widget. 


## :green_heart: How did you test it?

- A new unit test was added in `feedback_test`. 
- If you want to reproduce the issue: set the mode NAVIGATION, open the feedback widget, select DRAW, close and open again. You will see the DRAW remains active.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
