### PR TITLE
Remove `meta` dependency

### DIFF
--- a/feedback/CHANGELOG.md
+++ b/feedback/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.1]
+
+* Removed `meta` dependency
+
 ## [2.3.0]
 
 * bottom sheet gets closed on back press

--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -93,7 +93,6 @@ class FeedbackWidgetState extends State<FeedbackWidget>
     BackButtonInterceptor.remove(backButtonIntercept);
   }
 
-  @internal
   @visibleForTesting
   bool backButtonIntercept() {
     if (mode == FeedbackMode.draw && widget.isFeedbackVisible) {

--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -11,7 +11,6 @@ import 'package:feedback/src/screenshot.dart';
 import 'package:feedback/src/theme/feedback_theme.dart';
 import 'package:feedback/src/utilities/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 typedef FeedbackButtonPress = void Function(BuildContext context);
 

--- a/feedback/pubspec.yaml
+++ b/feedback/pubspec.yaml
@@ -1,6 +1,6 @@
 name: feedback
 description: A Flutter package for getting better feedback. It allows the user to give interactive feedback directly in the app.
-version: 2.3.0
+version: 2.3.1
 homepage: https://uekoetter.dev/
 repository: https://github.com/ueman/feedback
 issue_tracker: https://github.com/ueman/feedback/issues
@@ -14,7 +14,6 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  meta: ^1.3.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
## :scroll: Description
Removes the explicit `meta` dependency declaration

## :bulb: Motivation and Context
Removes `meta` explicit dependency to avoid future version conflicts (it was already outdated)
https://github.com/flutter/flutter/issues/95658

## :green_heart: How did you test it?
`meta` is still used as a transitive dependency and the tags used also come from the Flutter framework

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes