### PR TITLE
translation: Load localization dynamically

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -257,7 +257,7 @@ class GlobalFeedbackLocalizationsDelegate
           _supportedLocales[languageLocale]!);
     }
     // The default is english
-    return SynchronousFuture(const EnFeedbackLocalizations());
+    return SynchronousFuture(_supportedLocales[const Locale('en')]!);
   }
 
   @override


### PR DESCRIPTION
This way, when inheriting from the class, one can simply set
_supportedLocales without having to override load().

## :scroll: Description
Should theoretically make implementing translations easier and with less boilerplate code.


## :bulb: Motivation and Context
Remove the load() function from https://github.com/ueman/feedback/issues/160#issuecomment-1018361157


## :green_heart: How did you test it?
I didn't :)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
