### PR TITLE
enable snap for realsies this time

### DIFF
--- a/feedback/lib/src/feedback_bottom_sheet.dart
+++ b/feedback/lib/src/feedback_bottom_sheet.dart
@@ -103,8 +103,7 @@ class _DraggableFeedbackSheetState extends State<_DraggableFeedbackSheet> {
         ),
         Expanded(
           child: DraggableScrollableSheet(
-            // Should be enabled as soons as the Flutter version gets raised
-            // snap: true,
+            snap: true,
             minChildSize: collapsedHeight,
             initialChildSize: collapsedHeight,
             builder: (context, scrollController) {

--- a/feedback/pubspec.yaml
+++ b/feedback/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/ueman/feedback/issues
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.0.0'
+  flutter: '>=2.10.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
The new flutter release now supports snapping sheets!

This PR just enables snapping. I'll create a larger PR later that updates feedback to use the new sheet controller argument.

Tested by manually playing with it in my own app.