### PR TITLE
allow awaiting submission

### DIFF
--- a/feedback/lib/src/better_feedback.dart
+++ b/feedback/lib/src/better_feedback.dart
@@ -2,17 +2,17 @@ import 'dart:async';
 
 import 'package:feedback/feedback.dart';
 import 'package:feedback/src/debug.dart';
+import 'package:feedback/src/feedback_builder/string_feedback.dart';
 import 'package:feedback/src/feedback_data.dart';
 import 'package:feedback/src/feedback_widget.dart';
-import 'package:feedback/src/feedback_builder/string_feedback.dart';
 import 'package:feedback/src/theme/feedback_theme.dart';
 import 'package:feedback/src/utilities/feedback_app.dart';
 import 'package:feedback/src/utilities/renderer/renderer.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 /// The function to be called when the user submits his feedback.
-typedef OnSubmit = void Function(
+typedef OnSubmit = Future<void> Function(
   String feedback, {
   Map<String, dynamic>? extras,
 });


### PR DESCRIPTION
## :scroll: Description
Changed the `OnSubmit` `typedef` to return a `Future<void>` instead of just `void`.


## :bulb: Motivation and Context

I'm using a custom feedback sheet via `BetterFeedback.feedbackBuilder` and would like to be able to display a loading indicator while awaiting submission to complete. Otherwise, the UI sits on the feedback screen with no visible activity until submission completes. To the user, this may feel like the app has frozen momentarily.

## :green_heart: How did you test it?

1. My feedback widget is stateful and holds a `bool isSubmitting`. `OnSubmit` is passed to my feedback widget from `FeedbackBuilder`. A "Submit" button is displayed at the bottom of the sheet, which changes to a loading indicator when `isSubmitting` is `true`. It contains an `onPressed` similar to the following:

```dart
onPressed: () async {
  setState(() => isSubmitting = true);

  await widget.onSubmit(
    messageController.text,
    extras: <String, dynamic>{
      "subject": subjectController.text,
    },
  );

  setState(() => isSubmitting = false);
},
```

2. I ran the package's tests with `flutter test`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] All tests passing
- [x] No breaking changes

