### PR TITLE
fix: don't replace existing MediaQuery widget

### DIFF
--- a/feedback/lib/src/utilities/feedback_app.dart
+++ b/feedback/lib/src/utilities/feedback_app.dart
@@ -23,15 +23,24 @@ class FeedbackApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final themeWrapper = FeedbackTheme(
+      data: data ?? FeedbackThemeData(),
+      child: child,
+    );
+
+    Widget mediaQueryWrapper;
+
+    /// Don't replace existing MediaQuery widget if it exists.
+    if (MediaQuery.maybeOf(context) == null) {
+      mediaQueryWrapper = MediaQueryFromWindow(child: themeWrapper);
+    } else {
+      mediaQueryWrapper = themeWrapper;
+    }
+
     return FeedbackLocalization(
       delegates: localizationsDelegates,
       localeOverride: localeOverride,
-      child: MediaQueryFromWindow(
-        child: FeedbackTheme(
-          data: data ?? FeedbackThemeData(),
-          child: child,
-        ),
-      ),
+      child: mediaQueryWrapper,
     );
   }
 }


### PR DESCRIPTION
## :scroll: Description
Before wrapping the app widget in a new `MediaQuery` it's checking for an existing one. If there's already a `MediaQuery' Widget, it doesn't replace the old one.


## :bulb: Motivation and Context
I don't add the `BetterFeedback` widget above the `MaterialApp`, instead in the `builder` from `MaterialApp`, because I'm using [DevicePreview](https://pub.dev/packages/device_preview) and [ResponsiveFramework](https://pub.dev/packages/responsive_framework). They have to be above the `BetterFeedback` widget and manipulate the `MediaQuery`. So I changed this package to use the existing `MediaQuery` widget, if any.


## :green_heart: How did you test it?
I have tested the changes manually in my own project. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
