### PR TITLE
adds an exposed sheet contorller to the better feedback controller

### DIFF
--- a/feedback/example/android/build.gradle
+++ b/feedback/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/feedback/lib/src/feedback_bottom_sheet.dart
+++ b/feedback/lib/src/feedback_bottom_sheet.dart
@@ -103,6 +103,7 @@ class _DraggableFeedbackSheetState extends State<_DraggableFeedbackSheet> {
         ),
         Expanded(
           child: DraggableScrollableSheet(
+            controller: BetterFeedback.of(context).sheetController,
             snap: true,
             minChildSize: collapsedHeight,
             initialChildSize: collapsedHeight,

--- a/feedback/lib/src/feedback_controller.dart
+++ b/feedback/lib/src/feedback_controller.dart
@@ -1,11 +1,11 @@
-import 'package:feedback/src/better_feedback.dart';
+import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
 
 /// Controls the state of the feeback ui.
 class FeedbackController extends ChangeNotifier {
   bool _isVisible = false;
 
-  /// Wether the feedback ui is currently visible.
+  /// Whether the feedback ui is currently visible.
   bool get isVisible => _isVisible;
 
   /// This function is called when the user submits his feedback.
@@ -27,4 +27,11 @@ class FeedbackController extends ChangeNotifier {
     _isVisible = false;
     notifyListeners();
   }
+
+  /// The draggable scrollable sheet controller used by better feedback.
+  ///
+  /// The controller is only attached if [FeedbackThemeData.sheetIsDraggable] is
+  /// true and feedback is currently displayed.
+  final DraggableScrollableController sheetController =
+      DraggableScrollableController();
 }

--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -57,7 +57,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
   // rebuilding the feedback sheet mid-drag cancels the drag.
   // TODO(caseycrogers): replace `sheetProgress` with a direct reference to
   //   `DraggableScrollableController` when the latter gets into production.
-  //   See: https://github.com/flutter/flutter/pull/92440.
+  //   See: https://github.com/flutter/flutter/pull/135366.
   ValueNotifier<double> sheetProgress = ValueNotifier(0);
 
   @visibleForTesting


### PR DESCRIPTION
## :scroll: Description
This PR exposes a `DraggableScrollableController` from `FeedbackController`.
This was a PR I intended to do a long time ago, but it was blocking on a PR landing in `flutter/flutter` and that took so long that I forgot to get back to this ):

I have a handful of TODOs in other places that this PR unblocks, but I figured I'd do those in a follow up PR as they're much fussier and harder to land.

## :bulb: Motivation and Context
This PR allows users of `BetterFeedback` to listen to the state of the feedback sheet and manually manipulate it. This is useful for things like:
1. Manipulating the sheet from within your custom sheet content
2. Driving animations from within your sheet

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

1. Remove the public drag handle widget and automatically embed it in the user's sheet gated behind a bool in the feedback theme
2. Replace `sheetProgress` in the places where it is used with a direct reference to the sheet controller
(blocking on a PR to add `double get progress` to flutter/flutter https://github.com/flutter/flutter/pull/135366)  