### PR TITLE
feat: ✨ portuguese default locale

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -216,6 +216,24 @@ class PlFeedbackLocalizations extends FeedbackLocalizations {
   const PlFeedbackLocalizations();
 
   @override
+  String get submitButtonText => 'Wyślij';
+
+  @override
+  String get feedbackDescriptionText => 'Co poszło nie tak?';
+
+  @override
+  String get draw => 'Rysuj';
+
+  @override
+  String get navigate => 'Nawiguj';
+}
+
+/// Default portuguese localization
+class PtFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [PtFeedbackLocalizations].
+  const PtFeedbackLocalizations();
+
+  @override
   String get submitButtonText => 'Enviar';
 
   @override
@@ -228,23 +246,6 @@ class PlFeedbackLocalizations extends FeedbackLocalizations {
   String get navigate => 'Navegar';
 }
 
-/// Default portuguese localization
-class PtFeedbackLocalizations extends FeedbackLocalizations {
-  /// Creates a [PtFeedbackLocalizations].
-  const PtFeedbackLocalizations();
-
-  @override
-  String get submitButtonText => 'Wyślij';
-
-  @override
-  String get feedbackDescriptionText => 'Co poszło nie tak?';
-
-  @override
-  String get draw => 'Rysuj';
-
-  @override
-  String get navigate => 'Nawiguj';
-}
 // coverage:ignore-end
 
 /// This is a localization delegate, which includes all of the localizations

--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -216,6 +216,24 @@ class PlFeedbackLocalizations extends FeedbackLocalizations {
   const PlFeedbackLocalizations();
 
   @override
+  String get submitButtonText => 'Enviar';
+
+  @override
+  String get feedbackDescriptionText => 'Qual o problema?';
+
+  @override
+  String get draw => 'Desenhar';
+
+  @override
+  String get navigate => 'Navegar';
+}
+
+/// Default portuguese localization
+class PtFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [PtFeedbackLocalizations].
+  const PtFeedbackLocalizations();
+
+  @override
   String get submitButtonText => 'Wyślij';
 
   @override
@@ -227,7 +245,6 @@ class PlFeedbackLocalizations extends FeedbackLocalizations {
   @override
   String get navigate => 'Nawiguj';
 }
-
 // coverage:ignore-end
 
 /// This is a localization delegate, which includes all of the localizations
@@ -254,6 +271,7 @@ class GlobalFeedbackLocalizationsDelegate
     const Locale('tr'): const TrFeedbackLocalizations(),
     const Locale('zh'): const ZhFeedbackLocalizations(),
     const Locale('pl'): const PlFeedbackLocalizations(),
+    const Locale('pt'): const PtFeedbackLocalizations(),
   };
 
   /// The default locale to use. Note that this locale should ALWAYS be


### PR DESCRIPTION
## :scroll: Description
Adding default portuguese (pt) locale


## :bulb: Motivation and Context
Currently there isn't a FeedbackLocalizations for the Portuguese language


## :green_heart: How did you test it?
Running the example app with locale setted as "pt"

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Add it as a default localization

