### PR TITLE
feat: ✨ Gitlab onIssueCreated callback

### DIFF
--- a/feedback_gitlab/lib/src/feedback_gitlab.dart
+++ b/feedback_gitlab/lib/src/feedback_gitlab.dart
@@ -23,6 +23,20 @@ extension BetterFeedbackX on FeedbackController {
   ///   }
   /// )
   /// ```
+  /// You can also add the `onIssueCreated` callback if you want to, this way you will have access to the user feedback object after it was sent to gitlab.
+  /// It is a good way to toggle a loader when handling feedback this way.
+  /// ```dart
+  ///
+  /// BetterFeedback.of(context).showAndUploadToGitLab(
+  ///       projectId: 'gitlab-project-id',
+  ///       apiToken: 'gitlab-api-token',
+  ///       gitlabUrl: 'gitlab.org',
+  ///       onIssueCreated: (feedback) {
+  ///         print(feedback);
+  ///         yourLoaderController.hide();
+  ///       }
+  /// );
+  /// ```
   /// The API token needs access to:
   ///   - read_api
   ///   - write_repository

--- a/feedback_gitlab/lib/src/feedback_gitlab.dart
+++ b/feedback_gitlab/lib/src/feedback_gitlab.dart
@@ -32,13 +32,17 @@ extension BetterFeedbackX on FeedbackController {
     required String apiToken,
     String? gitlabUrl,
     http.Client? client,
+    OnFeedbackCallback? onIssueCreated,
   }) {
-    show(uploadToGitLab(
-      projectId: projectId,
-      apiToken: apiToken,
-      gitlabUrl: gitlabUrl,
-      client: client,
-    ));
+    show((feedback) async {
+      uploadToGitLab(
+        projectId: projectId,
+        apiToken: apiToken,
+        gitlabUrl: gitlabUrl,
+        client: client,
+        onIssueCreated: onIssueCreated,
+      );
+    });
   }
 }
 
@@ -50,6 +54,7 @@ OnFeedbackCallback uploadToGitLab({
   required String apiToken,
   String? gitlabUrl,
   http.Client? client,
+  OnFeedbackCallback? onIssueCreated,
 }) {
   final httpClient = client ?? http.Client();
   final baseUrl = gitlabUrl ?? 'gitlab.com';
@@ -94,5 +99,6 @@ OnFeedbackCallback uploadToGitLab({
       ),
       headers: {'PRIVATE-TOKEN': apiToken},
     );
+    await onIssueCreated?.call(feedback);
   };
 }

--- a/feedback_gitlab/lib/src/feedback_gitlab.dart
+++ b/feedback_gitlab/lib/src/feedback_gitlab.dart
@@ -48,15 +48,13 @@ extension BetterFeedbackX on FeedbackController {
     http.Client? client,
     OnFeedbackCallback? onIssueCreated,
   }) {
-    show((feedback) async {
-      uploadToGitLab(
-        projectId: projectId,
-        apiToken: apiToken,
-        gitlabUrl: gitlabUrl,
-        client: client,
-        onIssueCreated: onIssueCreated,
-      );
-    });
+    show(uploadToGitLab(
+      projectId: projectId,
+      apiToken: apiToken,
+      gitlabUrl: gitlabUrl,
+      client: client,
+      onIssueCreated: onIssueCreated,
+    ));
   }
 }
 

--- a/feedback_gitlab/test/feedback_gitlab_test.dart
+++ b/feedback_gitlab/test/feedback_gitlab_test.dart
@@ -8,6 +8,12 @@ import 'package:http/http.dart';
 import 'package:http_parser/http_parser.dart';
 
 void main() {
+  final feedback = UserFeedback(
+    screenshot: Uint8List.fromList([]),
+    text: 'foo bar',
+    extra: {'foo': 'bar'},
+  );
+
   test('uploads', () async {
     final mockClient = MockClient();
     var onFeedback = uploadToGitLab(
@@ -17,14 +23,28 @@ void main() {
       client: mockClient,
     );
 
-    onFeedback(UserFeedback(
-      screenshot: Uint8List.fromList([]),
-      text: 'foo bar',
-      extra: {'foo': 'bar'},
-    ));
+    onFeedback(feedback);
 
     final result = await mockClient.completer.future;
     expect(result, true);
+  });
+
+  test('onIssueCreated callback should be called', () async {
+    bool mockClient = false;
+    final client = MockClient();
+    var onFeedback = uploadToGitLab(
+      projectId: '123',
+      apiToken: '123',
+      gitlabUrl: 'example.org',
+      client: client,
+      onIssueCreated: (feedback) => mockClient = true,
+    );
+
+    onFeedback(feedback);
+
+    await client.completer.future;
+    await Future.delayed(const Duration(milliseconds: 200));
+    expect(mockClient, isTrue);
   });
 }
 


### PR DESCRIPTION
## :scroll: Description
- Added a callback parameter to uploadToGitLab method


## :bulb: Motivation and Context
- Currently there is no way of listening or even knowing when the API call for issue creation was completed, so when i call showAndUploadToGitLab() I just don't have a practical way to hide a loader if needed, for example

## :green_heart: How did you test it?
- Adding an unit test to _feedback_gitlab/test/feedback_gitlab_test.dart_

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
- It would be great to have something similar to this on feedback_sentry too