### PR TITLE
fix: broken link to sample app in README

### DIFF
--- a/feedback/README.md
+++ b/feedback/README.md
@@ -141,7 +141,7 @@ BetterFeedback.of(context).showAndUploadToSentry(
 | Firebase | [Firestore](https://pub.dev/packages/cloud_firestore), [Cloud Storage](https://pub.dev/packages/firebase_storage), [Database](https://pub.dev/packages/firebase_database)
 | Jira | Jira has a [REST API to create issues and upload files](https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/#creating-an-issue-examples) |
 | Trello | Trello has a [REST API to create issues and upload files](https://developer.atlassian.com/cloud/trello/rest/api-group-actions/) |
-| E-Mail | You can use the users email client like [in the sample app](https://github.com/ueman/feedback/blob/master/example/lib/main.dart) to send feedback to yourself using the [flutter_email_sender](https://pub.dev/packages/flutter_email_sender) plugin. |
+| E-Mail | You can use the users email client like [in the sample app](https://github.com/ueman/feedback/blob/master/feedback/example/lib/main.dart#L147-L160) to send feedback to yourself using the [flutter_email_sender](https://pub.dev/packages/flutter_email_sender) plugin. |
 
 If you have sample code on how to upload it to a platform, I would appreciate a pull request to the example app.
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
A link in the README of the feedback package was broken, linking to a non-existent GitHub page (see screenshot below).

The link was: https://github.com/ueman/feedback/blob/master/example/lib/main.dart
And the correct one would be: https://github.com/ueman/feedback/blob/master/feedback/example/lib/main.dart

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### Position of broken link on page
<img width="800" alt="Screenshot 2024-02-07 at 11 43 38" src="https://github.com/ueman/feedback/assets/75510543/4049d3c6-b682-4c26-8038-d9c1b1b2b1f6">

#### Result when clicking link
<img width="1489" alt="image" src="https://github.com/ueman/feedback/assets/75510543/2b7ad235-ae9b-4ffe-8853-37d652412fc9">


## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
