### PR TITLE
Feature/support for gr bg locals

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -264,6 +264,42 @@ class JaFeedbackLocalizations extends FeedbackLocalizations {
   String get navigate => 'ナビゲート';
 }
 
+/// Default greek localization
+class ElFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [ElFeedbackLocalizations]
+  const ElFeedbackLocalizations();
+
+  @override
+  String get submitButtonText => 'Υποβολή';
+
+  @override
+  String get feedbackDescriptionText => 'Τι πρόβλημα υπάρχει;';
+
+  @override
+  String get draw => 'Σχεδίαση';
+
+  @override
+  String get navigate => 'Πλοήγηση';
+}
+
+/// Default bulgarian localization
+class BgFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [BgFeedbackLocalizations]
+  const BgFeedbackLocalizations();
+
+  @override
+  String get submitButtonText => 'Подчинение';
+
+  @override
+  String get feedbackDescriptionText => 'текст на описанието';
+
+  @override
+  String get draw => 'Нарисувай';
+
+  @override
+  String get navigate => 'Навигиране';
+}
+
 // coverage:ignore-end
 
 /// This is a localization delegate, which includes all of the localizations

--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -328,6 +328,8 @@ class GlobalFeedbackLocalizationsDelegate
     const Locale('pl'): const PlFeedbackLocalizations(),
     const Locale('pt'): const PtFeedbackLocalizations(),
     const Locale('ja'): const JaFeedbackLocalizations(),
+    const Locale('el'): const ElFeedbackLocalizations(),
+    const Locale('bg'): const BgFeedbackLocalizations(),
   };
 
   /// The default locale to use. Note that this locale should ALWAYS be


### PR DESCRIPTION
## :scroll: Description
Added support for Greek and Bulgarian localizations.


## :bulb: Motivation and Context
The motivation behind the PR is because I need these two extra localizations for an I'm working on.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [x ] No breaking changes
