### PR TITLE
feature: add feedback_github

### DIFF
--- a/feedback_github/.gitignore
+++ b/feedback_github/.gitignore
@@ -1,0 +1,29 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/feedback_github/.metadata
+++ b/feedback_github/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: b22742018b3edf16c6cadd7b76d9db5e7f9064b5
+  channel: stable
+
+project_type: package

--- a/feedback_github/CHANGELOG.md
+++ b/feedback_github/CHANGELOG.md
@@ -1,0 +1,16 @@
+## 3.0.0
+
+* Update dependencies
+
+## 2.2.0
+
+* This update is compatible with feedback 2.2.0
+* Improve documentation
+
+## 2.0.0+1
+
+* Update Readme
+
+## 2.0.0
+
+* Initial version

--- a/feedback_github/LICENSE
+++ b/feedback_github/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Jonas Uekötter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/feedback_github/README.md
+++ b/feedback_github/README.md
@@ -11,7 +11,18 @@ The latest version is <a href="https://pub.dev/packages/feedback_github"><img sr
 dependencies:
   flutter:
     sdk: flutter
-  feedback_github: x.y.z # use the latest version found on pub.dev
+  feedback_github:
+    git: 
+      url: https://github.com/defuncart/fork_feedback/
+      path: feedback_github
+      ref: feature/add-create-issue-on-github
+
+dependency_overrides:
+  feedback:
+    git: 
+      url: https://github.com/defuncart/fork_feedback/
+      path: feedback
+      ref: feature/add-create-issue-on-github
 ```
 
 Then, run `flutter pub get` in your terminal.
@@ -37,13 +48,22 @@ void main() {
 
 Provide a way to show the feedback panel by calling 
 ```dart
-BetterFeedback.of(context).showAndUploadToGitLab(
-    projectId: 'project-Id',
-    apiToken: 'api-token',
+BetterFeedback.of(context).showAndUploadToGitHub(
+  username: 'username',
+  repository: 'repository',
+  authToken: 'github_pat_',
+  labels: ['feedback'],
+  assignees: ['username'],
+  logs: 'log1\nlog2',
+  imageId: Uuid().v4(),
 );
 ```
 Provide a way to hide the feedback panel by calling  `BetterFeedback.of(context).hide();` 
 
+
+## Repository Setup
+
+The github repository `repository` for user `username` requires a `issue_images` branch where the images for issue can be uploaded to.
 
 ## 📣  Author
 

--- a/feedback_github/README.md
+++ b/feedback_github/README.md
@@ -1,0 +1,60 @@
+# feedback_github
+
+## 🚀 Getting Started
+
+### Setup
+
+First, you will need to add `feedback_github` to your `pubspec.yaml`.
+The latest version is <a href="https://pub.dev/packages/feedback_github"><img src="https://img.shields.io/pub/v/feedback_github.svg" alt="pub.dev"></a>.
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  feedback_github: x.y.z # use the latest version found on pub.dev
+```
+
+Then, run `flutter pub get` in your terminal.
+
+### Use it
+
+Just wrap your app in a `BetterFeedback` widget.
+To show the feedback view just call `BetterFeedback.of(context).show(...);`.
+The callback gets called when the user submits his feedback. 
+
+```dart
+import 'package:feedback/feedback.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(
+    BetterFeedback(
+      child: const MyApp(),
+    ),
+  );
+}
+```
+
+Provide a way to show the feedback panel by calling 
+```dart
+BetterFeedback.of(context).showAndUploadToGitLab(
+    projectId: 'project-Id',
+    apiToken: 'api-token',
+);
+```
+Provide a way to hide the feedback panel by calling  `BetterFeedback.of(context).hide();` 
+
+
+## 📣  Author
+
+- Jonas Uekötter: [GitHub](https://github.com/ueman) and [Twitter](https://twitter.com/ue_man)
+
+## Issues, questions and contributing
+
+You can raise issues [here](https://github.com/ueman/feedback/issues).
+If you've got a question do not hesitate to ask it [here](https://github.com/ueman/feedback/discussions).
+Contributions are also welcome. You can do a pull request on GitHub [here](https://github.com/ueman/feedback/pulls). Please take a look at [`up for grabs`](https://github.com/ueman/feedback/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) issues first.
+
+## Sponsoring
+
+I'm working on my packages on my free-time, but I don't have as much time as I would. If this package or any other package I created is helping you, please consider to [sponsor](https://github.com/ueman#sponsor-me) me. By doing so, I will prioritize your issues or your pull-requests before the others.

--- a/feedback_github/README.md
+++ b/feedback_github/README.md
@@ -54,7 +54,7 @@ BetterFeedback.of(context).showAndUploadToGitHub(
   authToken: 'github_pat_',
   labels: ['feedback'],
   assignees: ['username'],
-  logs: 'log1\nlog2',
+  customMarkdown: '**Hello World**',
   imageId: Uuid().v4(),
 );
 ```

--- a/feedback_github/analysis_options.yaml
+++ b/feedback_github/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:

--- a/feedback_github/example/example.dart
+++ b/feedback_github/example/example.dart
@@ -1,0 +1,74 @@
+import 'package:feedback_github/feedback_github.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const BetterFeedback(child: MyApp()));
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text('You have pushed the button this many times:'),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            ElevatedButton(
+              onPressed: () {
+                BetterFeedback.of(context).showAndUploadToGitHub(
+                  username: 'username',
+                  repository: 'repository',
+                  authToken: 'authToken',
+                );
+              },
+              child: const Text('Show Feedback view'),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/feedback_github/lib/feedback_github.dart
+++ b/feedback_github/lib/feedback_github.dart
@@ -1,0 +1,5 @@
+library feedback_github;
+
+export 'package:feedback/feedback.dart';
+
+export 'src/feedback_github.dart';

--- a/feedback_github/lib/src/feedback_github.dart
+++ b/feedback_github/lib/src/feedback_github.dart
@@ -20,6 +20,7 @@ extension BetterFeedbackX on FeedbackController {
   ///       authToken: 'github_pat_token',
   ///       labels: ['feedback'],
   ///       assignees: ['dash'],
+  ///       customMarkdown: '**Hello World**',
   ///       imageId: 'unique-id',
   ///     );
   ///   }
@@ -38,7 +39,7 @@ extension BetterFeedbackX on FeedbackController {
     required String authToken,
     List<String>? labels,
     List<String>? assignees,
-    String? logs,
+    String? customMarkdown,
     required String imageId,
     String? githubUrl,
     http.Client? client,
@@ -49,7 +50,7 @@ extension BetterFeedbackX on FeedbackController {
       authToken: authToken,
       labels: labels,
       assignees: assignees,
-      logs: logs,
+      customMarkdown: customMarkdown,
       imageId: imageId,
       githubUrl: githubUrl,
       client: client,
@@ -66,7 +67,7 @@ OnFeedbackCallback uploadToGitLab({
   required String authToken,
   List<String>? labels,
   List<String>? assignees,
-  String? logs,
+  String? customMarkdown,
   required String imageId,
   String? githubUrl,
   http.Client? client,
@@ -109,15 +110,7 @@ OnFeedbackCallback uploadToGitLab({
       // body contains message and optional logs
       final body = '''${feedback.text}
 ![]($imageUrl)
-${logs != null ? '''
-<details>
-<summary>Logs</summary>
-
-```
-$logs
-```
-</details>
-''' : ''}
+${customMarkdown ?? ''}
 ''';
 
       uri = Uri.https(

--- a/feedback_github/lib/src/feedback_github.dart
+++ b/feedback_github/lib/src/feedback_github.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+
+import 'package:feedback/feedback.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// This is an extension to make it easier to call
+/// [showAndUploadToGitHub].
+extension BetterFeedbackX on FeedbackController {
+  /// Example usage:
+  /// ```dart
+  /// import 'package:feedback_github/feedback_github.dart';
+  ///
+  /// RaisedButton(
+  ///   child: Text('Click me'),
+  ///   onPressed: (){
+  ///     BetterFeedback.of(context).showAndUploadToGitHub
+  ///       username: 'username',
+  ///       repository: 'repository',
+  ///       authToken: 'github_pat_token',
+  ///       labels: ['feedback'],
+  ///       assignees: ['dash'],
+  ///     );
+  ///   }
+  /// )
+  /// ```
+  /// The API token (Personal Access Token) needs access to:
+  ///   - issues (read and write)
+  ///   - metadata (read)
+  /// See https://docs.github.com/en/enterprise-server@3.9/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+  void showAndUploadToGitHub({
+    required String username,
+    required String repository,
+    required String authToken,
+    List<String>? labels,
+    List<String>? assignees,
+    String? logs,
+    String? githubUrl,
+    http.Client? client,
+  }) {
+    show(uploadToGitLab(
+      username: username,
+      repository: repository,
+      authToken: authToken,
+      labels: labels,
+      assignees: assignees,
+      logs: logs,
+      githubUrl: githubUrl,
+      client: client,
+    ));
+  }
+}
+
+/// See [BetterFeedbackX.showAndUploadToGitHub].
+/// This is just [visibleForTesting].
+@visibleForTesting
+OnFeedbackCallback uploadToGitLab({
+  required String username,
+  required String repository,
+  required String authToken,
+  List<String>? labels,
+  List<String>? assignees,
+  String? logs,
+  String? githubUrl,
+  http.Client? client,
+}) {
+  final httpClient = client ?? http.Client();
+  final baseUrl = githubUrl ?? 'api.github.com';
+
+  return (UserFeedback feedback) async {
+    final uri = Uri.https(
+      baseUrl,
+      'repos/$username/$repository/issues',
+    );
+
+    // title contains first 20 characters of message, with a default for empty feedback
+    final title = feedback.text.length > 20
+        ? '${feedback.text.substring(0, 20)}...'
+        : feedback.text.isEmpty
+            ? 'New Feedback'
+            : feedback.text;
+    // body contains message and optional logs
+    final body = '''${feedback.text}
+    ${logs != null ? '''
+<details>
+<summary>Logs</summary>
+
+```
+$logs
+```
+</details>
+''' : ''}
+''';
+
+    // https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
+    final response = await httpClient.post(
+      uri,
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': 'Bearer $authToken',
+      },
+      body: jsonEncode({
+        'title': title,
+        'body': body,
+        if (labels != null && labels.isNotEmpty) 'labels': labels,
+        if (assignees != null && assignees.isNotEmpty) 'assignees': assignees,
+      }),
+    );
+
+    print(response.body);
+
+    if (response.statusCode == 201) {
+      print('uploaded');
+    } else {
+      print('not uploaded');
+    }
+  };
+}

--- a/feedback_github/pubspec.yaml
+++ b/feedback_github/pubspec.yaml
@@ -1,0 +1,25 @@
+name: feedback_github
+description: A Flutter package for getting better feedback. It allows the user to give interactive feedback directly in the app and upload it as an issue to GitLab
+version: 3.0.0
+homepage: https://uekoetter.dev
+repository: https://github.com/ueman/feedback
+issue_tracker: https://github.com/ueman/feedback/issues
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  feedback: ^3.0.0
+  http: ^1.0.0
+  http_parser: ^4.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/feedback_github/test/feedback_gitlab_test.dart
+++ b/feedback_github/test/feedback_gitlab_test.dart
@@ -1,0 +1,100 @@
+// import 'dart:async';
+// import 'dart:convert';
+// import 'dart:typed_data';
+
+// import 'package:feedback_github/feedback_github.dart';
+// import 'package:flutter_test/flutter_test.dart';
+// import 'package:http/http.dart';
+// import 'package:http_parser/http_parser.dart';
+
+// void main() {
+//   test('uploads', () async {
+//     final mockClient = MockClient();
+//     var onFeedback = uploadToGitHub(
+//       projectId: '123',
+//       apiToken: '123',
+//       githubUrl: 'example.org',
+//       client: mockClient,
+//     );
+
+//     onFeedback(UserFeedback(
+//       screenshot: Uint8List.fromList([]),
+//       text: 'foo bar',
+//       extra: {'foo': 'bar'},
+//     ));
+
+//     final result = await mockClient.completer.future;
+//     expect(result, true);
+//   });
+// }
+
+// class MockClient extends BaseClient {
+//   int calls = 0;
+//   Completer<bool> completer = Completer<bool>();
+
+//   @override
+//   Future<StreamedResponse> send(BaseRequest request) async {
+//     calls++;
+//     if (request is MultipartRequest) {
+//       return toStreamedResponse(
+//         request,
+//         onMultipartRequest(request),
+//       );
+//     }
+
+//     if (request is Request) {
+//       completer.complete(true);
+//       return toStreamedResponse(
+//         request,
+//         onRequest(request),
+//       );
+//     }
+
+//     fail('This should not be reached');
+//   }
+
+//   Response onRequest(Request request) {
+//     expect(request.method, 'POST');
+//     expect(
+//       request.url,
+//       Uri.parse(
+//         'https://example.org/api/v4/projects/123/issues?title=foo+bar&description=foo+bar%0A%0A%7Bfoo%3A+bar%7D',
+//       ),
+//     );
+//     expect(request.headers, {'PRIVATE-TOKEN': '123'});
+//     return Response('', 200);
+//   }
+
+//   Response onMultipartRequest(MultipartRequest request) {
+//     expect(request.method, 'POST');
+//     expect(request.url, Uri.parse('https://example.org/api/v4/projects/123/uploads'));
+//     expect(request.headers, {'PRIVATE-TOKEN': '123'});
+//     expect(request.fields['id'], '123');
+//     expect(request.files.length, 1);
+
+//     var file = request.files.first;
+
+//     expect(file.field, 'file');
+//     expect(file.contentType.mimeType, 'image/png');
+//     expect(file.filename, 'feedback.png');
+//     expect(
+//       file.contentType.mimeType,
+//       MediaType('image', 'png').mimeType,
+//     );
+
+//     return Response(jsonEncode({'markdown': ''}), 200);
+//   }
+
+//   StreamedResponse toStreamedResponse(BaseRequest request, Response response) {
+//     return StreamedResponse(
+//       ByteStream.fromBytes(response.bodyBytes),
+//       response.statusCode,
+//       contentLength: response.contentLength,
+//       request: request,
+//       headers: response.headers,
+//       isRedirect: response.isRedirect,
+//       persistentConnection: response.persistentConnection,
+//       reasonPhrase: response.reasonPhrase,
+//     );
+//   }
+// }


### PR DESCRIPTION
## STATUS
- POC, ready for API review
- Issue can be created with text, labels & assignee
- Optional logs can be supplied
- Image needs to be upload to a branch of repository (via content api). Did not find a way to upload as part of issue.
- No error handling

![Bildschirmfoto 2024-02-24 um 17 40 48](https://github.com/ueman/feedback/assets/13286425/e02d3685-fd19-4714-a7f2-0ed2531bbc0e)

## API Considerations
Adding a new package `feedback_github`, however perhaps a common package `feedback_git` could also be considered. This would be a breaking change for `feedback_gitlab`.

## :scroll: Description
Similar to feedback_gitlab, adds ability to create an issue on GitHub with user's feedback.

## :bulb: Motivation and Context
Suggestion for #269 

## :green_heart: How did you test it?
N/A

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
N/A