### PR TITLE
feat(translation): add Spanish support in localization delegate

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -300,6 +300,24 @@ class BgFeedbackLocalizations extends FeedbackLocalizations {
   String get navigate => 'Навигиране';
 }
 
+/// Default spanish localization
+class EsFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [EsFeedbackLocalizations]
+  const EsFeedbackLocalizations();
+
+  @override
+  String get submitButtonText => 'Enviar';
+
+  @override
+  String get feedbackDescriptionText => '¿Cuál es el problema?';
+
+  @override
+  String get draw => 'Dibujar';
+
+  @override
+  String get navigate => 'Navegar';
+}
+
 // coverage:ignore-end
 
 /// This is a localization delegate, which includes all of the localizations
@@ -330,6 +348,7 @@ class GlobalFeedbackLocalizationsDelegate
     const Locale('ja'): const JaFeedbackLocalizations(),
     const Locale('el'): const ElFeedbackLocalizations(),
     const Locale('bg'): const BgFeedbackLocalizations(),
+    const Locale('es'): const EsFeedbackLocalizations()
   };
 
   /// The default locale to use. Note that this locale should ALWAYS be


### PR DESCRIPTION
## :scroll: Description
Only translation file is affected with this change, it adds Spanish language as supported by delegate with the default translation.


## :bulb: Motivation and Context
This should close request #283 to add Spanish support on default feedback


## :green_heart: How did you test it?
- Modifying the example locale to 'es'.
- Testing with a physical device

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [  ] I added tests to verify changes
- [  ] I updated the docs if needed
- [  ] All tests passing
- [x] No breaking changes

## 🖼️ Screenshot
![image](https://github.com/ueman/feedback/assets/37549606/071e7aff-dfcc-434f-9419-aad0e11421d0)
