### PR TITLE
Farsi has been added as a localization

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -86,7 +86,7 @@ class EnFeedbackLocalizations extends FeedbackLocalizations {
 
 /// Default persian localization
 class FaFeedbackLocalizations extends FeedbackLocalizations {
-  /// Creates a [EnFeedbackLocalizations].
+  /// Creates a [FaFeedbackLocalizations].
   const FaFeedbackLocalizations();
 
   @override

--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -99,7 +99,7 @@ class FaFeedbackLocalizations extends FeedbackLocalizations {
   String get draw => 'رسم';
 
   @override
-  String get navigate => 'انتقالÏ';
+  String get navigate => 'انتقال';
 }
 
 /// Default french localization

--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -84,6 +84,24 @@ class EnFeedbackLocalizations extends FeedbackLocalizations {
   String get navigate => 'Navigate';
 }
 
+/// Default persian localization
+class FaFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [EnFeedbackLocalizations].
+  const FaFeedbackLocalizations();
+
+  @override
+  String get submitButtonText => 'تایید';
+
+  @override
+  String get feedbackDescriptionText => 'مشکل چیست ؟ ';
+
+  @override
+  String get draw => 'رسم';
+
+  @override
+  String get navigate => 'انتقالÏ';
+}
+
 /// Default french localization
 class FrFeedbackLocalizations extends FeedbackLocalizations {
   /// Creates a [FrFeedbackLocalizations].
@@ -348,7 +366,8 @@ class GlobalFeedbackLocalizationsDelegate
     const Locale('ja'): const JaFeedbackLocalizations(),
     const Locale('el'): const ElFeedbackLocalizations(),
     const Locale('bg'): const BgFeedbackLocalizations(),
-    const Locale('es'): const EsFeedbackLocalizations()
+    const Locale('es'): const EsFeedbackLocalizations(),
+    const Locale('fa'): const FaFeedbackLocalizations(),
   };
 
   /// The default locale to use. Note that this locale should ALWAYS be

--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -93,13 +93,13 @@ class FaFeedbackLocalizations extends FeedbackLocalizations {
   String get submitButtonText => 'تایید';
 
   @override
-  String get feedbackDescriptionText => 'مشکل چیست ؟ ';
+  String get feedbackDescriptionText => 'چه مشکلی پیش آمده ؟';
 
   @override
   String get draw => 'رسم';
 
   @override
-  String get navigate => 'انتقال';
+  String get navigate => 'پیمایش';
 }
 
 /// Default french localization


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
I have added Farsi as a localization.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Persian speakers who use Farsi can now utilize the "fa" localization.
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I made a minor change to mirror your code and tested the syntax of my translation using your sample.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] I updated the docs if needed
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
