### PR TITLE
Update feedback_sentry to use sentry: ^8.0.0

### DIFF
--- a/feedback_sentry/pubspec.yaml
+++ b/feedback_sentry/pubspec.yaml
@@ -1,6 +1,6 @@
 name: feedback_sentry
 description: A Flutter package for getting better feedback. It allows the user to give interactive feedback directly in the app and upload it to Sentry.io
-version: 3.0.0
+version: 4.0.0
 homepage: https://uekoetter.dev
 repository: https://github.com/ueman/feedback
 issue_tracker: https://github.com/ueman/feedback/issues

--- a/feedback_sentry/pubspec.yaml
+++ b/feedback_sentry/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   feedback: ^3.0.0
-  sentry: ^7.0.0
+  sentry: ^8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## :scroll: Description
This PR updates `pubspec.yaml` file for the feedback_sentry setting the version constraint of `sentry` to `^8.0.0`. Although the changes in `sentry: ^8.0.0` don't affect this packages they might affect apps using it so I also updated the version of this package to 4.0.0.


## :bulb: Motivation and Context
The Sentry team released version 8.0.0 of the sentry package on [Apr 22, 2024](https://pub.dev/packages/sentry/versions). As it is a new major version, packages depending on it needs to update its version constraints. Closes #301.


## :green_heart: How did you test it?
Running the test with `flutter test`:
```
flutter test test/feedback_sentry_test.dart     
00:01 +1: All tests passed! 
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
