### PR TITLE
Add a copy with method to FeedbackThemeData

### DIFF
--- a/feedback/lib/src/theme/feedback_theme.dart
+++ b/feedback/lib/src/theme/feedback_theme.dart
@@ -41,6 +41,7 @@ class FeedbackThemeData {
       this.bottomSheetDescriptionStyle = _defaultBottomSheetDescriptionStyle,
       this.bottomSheetTextInputStyle = _defaultBottomSheetTextInputStyle,
       this.sheetIsDraggable = true,
+      Brightness? brightness,
       Color? dragHandleColor,
       ColorScheme? colorScheme})
       :
@@ -50,8 +51,8 @@ class FeedbackThemeData {
           // ignore: prefer_is_empty
           drawColors.length > 0,
           'There must be at least one color to draw with',
-        ),
-        brightness = ThemeData.estimateBrightnessForColor(feedbackSheetColor) {
+        ) {
+    brightness ??= ThemeData.estimateBrightnessForColor(feedbackSheetColor);
     final bool isDark = brightness == Brightness.dark;
     this.dragHandleColor =
         dragHandleColor ?? (isDark ? Colors.black26 : Colors.white38);
@@ -71,6 +72,7 @@ class FeedbackThemeData {
           color: Colors.white,
         ),
         sheetIsDraggable: sheetIsDraggable,
+        brightness: Brightness.dark,
       );
 
   /// Create a light version of the [FeedbackThemeData]
@@ -81,10 +83,11 @@ class FeedbackThemeData {
         feedbackSheetColor: _lightGrey,
         bottomSheetDescriptionStyle: _defaultBottomSheetDescriptionStyle,
         sheetIsDraggable: sheetIsDraggable,
+        brightness: Brightness.light,
       );
 
   /// Brightness of the theme based on the [background] color
-  final Brightness brightness;
+  late final Brightness brightness;
 
   /// The background of the feedback view.
   final Color background;
@@ -135,6 +138,7 @@ class FeedbackThemeData {
     TextStyle? bottomSheetTextInputStyle,
     bool? sheetIsDraggable,
     Color? dragHandleColor,
+    Brightness? brightness,
     ColorScheme? colorScheme,
   }) {
     return FeedbackThemeData(
@@ -150,6 +154,7 @@ class FeedbackThemeData {
           bottomSheetTextInputStyle ?? this.bottomSheetTextInputStyle,
       sheetIsDraggable: sheetIsDraggable ?? this.sheetIsDraggable,
       dragHandleColor: dragHandleColor ?? this.dragHandleColor,
+      brightness: brightness ?? this.brightness,
       colorScheme: colorScheme ?? this.colorScheme,
     );
   }

--- a/feedback/lib/src/theme/feedback_theme.dart
+++ b/feedback/lib/src/theme/feedback_theme.dart
@@ -122,6 +122,37 @@ class FeedbackThemeData {
 
   /// [ColorScheme] on the feedback UI
   late final ColorScheme colorScheme;
+
+  /// Creates a copy of the current [FeedbackThemeData] with the given
+  /// optional fields replaced with the given values.
+  FeedbackThemeData copyWith({
+    Color? background,
+    Color? feedbackSheetColor,
+    double? feedbackSheetHeight,
+    Color? activeFeedbackModeColor,
+    List<Color>? drawColors,
+    TextStyle? bottomSheetDescriptionStyle,
+    TextStyle? bottomSheetTextInputStyle,
+    bool? sheetIsDraggable,
+    Color? dragHandleColor,
+    ColorScheme? colorScheme,
+  }) {
+    return FeedbackThemeData(
+      background: background ?? this.background,
+      feedbackSheetColor: feedbackSheetColor ?? this.feedbackSheetColor,
+      feedbackSheetHeight: feedbackSheetHeight ?? this.feedbackSheetHeight,
+      activeFeedbackModeColor:
+          activeFeedbackModeColor ?? this.activeFeedbackModeColor,
+      drawColors: drawColors ?? this.drawColors,
+      bottomSheetDescriptionStyle:
+          bottomSheetDescriptionStyle ?? this.bottomSheetDescriptionStyle,
+      bottomSheetTextInputStyle:
+          bottomSheetTextInputStyle ?? this.bottomSheetTextInputStyle,
+      sheetIsDraggable: sheetIsDraggable ?? this.sheetIsDraggable,
+      dragHandleColor: dragHandleColor ?? this.dragHandleColor,
+      colorScheme: colorScheme ?? this.colorScheme,
+    );
+  }
 }
 
 /// Provides an instance of [FeedbackThemeData] for all descendants.

--- a/feedback/lib/src/theme/feedback_theme.dart
+++ b/feedback/lib/src/theme/feedback_theme.dart
@@ -52,7 +52,8 @@ class FeedbackThemeData {
           drawColors.length > 0,
           'There must be at least one color to draw with',
         ) {
-    brightness ??= ThemeData.estimateBrightnessForColor(feedbackSheetColor);
+    this.brightness =
+        brightness ??= ThemeData.estimateBrightnessForColor(feedbackSheetColor);
     final bool isDark = brightness == Brightness.dark;
     this.dragHandleColor =
         dragHandleColor ?? (isDark ? Colors.black26 : Colors.white38);

--- a/feedback/test/theme/feedback_theme_test.dart
+++ b/feedback/test/theme/feedback_theme_test.dart
@@ -1,0 +1,61 @@
+import 'package:feedback/feedback.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('copyWith overwrites all properties without changing original', () {
+    final theme = FeedbackThemeData(
+      background: Colors.grey,
+      feedbackSheetColor: Colors.white,
+      feedbackSheetHeight: .25,
+      activeFeedbackModeColor: Colors.blue,
+      drawColors: [Colors.orange, Colors.green],
+      bottomSheetDescriptionStyle: const TextStyle(color: Colors.black),
+      bottomSheetTextInputStyle: const TextStyle(color: Colors.white),
+      sheetIsDraggable: true,
+      brightness: Brightness.light,
+      dragHandleColor: Colors.white,
+      colorScheme: const ColorScheme.light(),
+    );
+
+    final copy = theme.copyWith(
+      background: Colors.red,
+      feedbackSheetColor: Colors.blue,
+      feedbackSheetHeight: .5,
+      activeFeedbackModeColor: Colors.green,
+      drawColors: [Colors.red, Colors.blue],
+      bottomSheetDescriptionStyle: const TextStyle(color: Colors.green),
+      bottomSheetTextInputStyle: const TextStyle(color: Colors.yellow),
+      sheetIsDraggable: false,
+      brightness: Brightness.dark,
+      dragHandleColor: Colors.black,
+      colorScheme: const ColorScheme.dark(),
+    );
+
+    // ensure overrides apply
+    expect(copy.background, Colors.red);
+    expect(copy.feedbackSheetColor, Colors.blue);
+    expect(copy.feedbackSheetHeight, .5);
+    expect(copy.activeFeedbackModeColor, Colors.green);
+    expect(copy.drawColors, [Colors.red, Colors.blue]);
+    expect(copy.bottomSheetDescriptionStyle, const TextStyle(color: Colors.green));
+    expect(copy.bottomSheetTextInputStyle, const TextStyle(color: Colors.yellow));
+    expect(copy.sheetIsDraggable, false);
+    expect(copy.brightness, Brightness.dark);
+    expect(copy.dragHandleColor, Colors.black);
+    expect(copy.colorScheme, const ColorScheme.dark());
+
+    // ensure original theme is not modified
+    expect(theme.background, Colors.grey);
+    expect(theme.feedbackSheetColor, Colors.white);
+    expect(theme.feedbackSheetHeight, .25);
+    expect(theme.activeFeedbackModeColor, Colors.blue);
+    expect(theme.drawColors, [Colors.orange, Colors.green]);
+    expect(theme.bottomSheetDescriptionStyle, const TextStyle(color: Colors.black));
+    expect(theme.bottomSheetTextInputStyle, const TextStyle(color: Colors.white));
+    expect(theme.sheetIsDraggable, true);
+    expect(theme.brightness, Brightness.light);
+    expect(theme.dragHandleColor, Colors.white);
+    expect(theme.colorScheme, const ColorScheme.light());
+  });
+}


### PR DESCRIPTION
## :scroll: Description
Adds a `copyWith` method to `FeedbackThemeData`. Also adds `brightness` as a settable property.

## :bulb: Motivation and Context
This fixes issue #311.

## :green_heart: How did you test it?
By calling `copyWith` in the example and seeing its results.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
