### PR TITLE
Add option to pass a custom `screenshotController`

### DIFF
--- a/feedback/lib/src/better_feedback.dart
+++ b/feedback/lib/src/better_feedback.dart
@@ -5,6 +5,7 @@ import 'package:feedback/src/debug.dart';
 import 'package:feedback/src/feedback_builder/string_feedback.dart';
 import 'package:feedback/src/feedback_data.dart';
 import 'package:feedback/src/feedback_widget.dart';
+import 'package:feedback/src/screenshot.dart';
 import 'package:feedback/src/theme/feedback_theme.dart';
 import 'package:feedback/src/utilities/feedback_app.dart';
 import 'package:feedback/src/utilities/renderer/renderer.dart';
@@ -112,6 +113,7 @@ class BetterFeedback extends StatefulWidget {
     this.localeOverride,
     this.mode = FeedbackMode.draw,
     this.pixelRatio = 3.0,
+    this.screenshotController,
   }) : assert(
           pixelRatio > 0,
           'pixelRatio needs to be larger than 0',
@@ -176,6 +178,10 @@ class BetterFeedback extends StatefulWidget {
   /// for information on the underlying implementation.
   final double pixelRatio;
 
+  /// Manages capturing a screenshot of the app's widget tree.
+  /// If `screenshotController` is null, a new instance will be created by default,
+  final ScreenshotController? screenshotController;
+
   /// Call `BetterFeedback.of(context)` to get an
   /// instance of [FeedbackData] on which you can call `.show()` or `.hide()`
   /// to enable or disable the feedback view.
@@ -236,6 +242,8 @@ class _BetterFeedbackState extends State<BetterFeedback> {
                 pixelRatio: widget.pixelRatio,
                 feedbackBuilder:
                     widget.feedbackBuilder ?? simpleFeedbackBuilder,
+                screenshotController:
+                    widget.screenshotController ?? ScreenshotController(),
                 child: widget.child,
               );
             },

--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -27,6 +27,7 @@ class FeedbackWidget extends StatefulWidget {
     required this.mode,
     required this.pixelRatio,
     required this.feedbackBuilder,
+    required this.screenshotController,
   }) : assert(
           // This way, we can have a const constructor
           // ignore: prefer_is_empty
@@ -39,8 +40,8 @@ class FeedbackWidget extends StatefulWidget {
   final double pixelRatio;
   final Widget child;
   final List<Color> drawColors;
-
   final FeedbackBuilder feedbackBuilder;
+  final ScreenshotController screenshotController;
 
   @override
   FeedbackWidgetState createState() => FeedbackWidgetState();
@@ -62,7 +63,6 @@ class FeedbackWidgetState extends State<FeedbackWidget>
   @visibleForTesting
   late PainterController painterController = create();
 
-  ScreenshotController screenshotController = ScreenshotController();
   TextEditingController textEditingController = TextEditingController();
 
   late FeedbackMode mode = widget.mode;
@@ -153,7 +153,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
                 // Place the screenshot here so that the widget tree isn't being
                 // arbitrarily rebuilt.
                 child: Screenshot(
-                  controller: screenshotController,
+                  controller: widget.screenshotController,
                   child: PaintOnChild(
                     controller: painterController,
                     isPaintingActive:
@@ -270,7 +270,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
                                 await _sendFeedback(
                                   context,
                                   BetterFeedback.of(context).onFeedback!,
-                                  screenshotController,
+                                  widget.screenshotController,
                                   feedback,
                                   widget.pixelRatio,
                                   extras: extras,

--- a/feedback/lib/src/screenshot.dart
+++ b/feedback/lib/src/screenshot.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 class ScreenshotController {
-  final GlobalKey _containerKey = GlobalKey();
+  final GlobalKey containerKey = GlobalKey();
 
   Future<Uint8List> capture({
     double pixelRatio = 1,
@@ -15,7 +15,7 @@ class ScreenshotController {
   }) {
     //Delay is required. See Issue https://github.com/flutter/flutter/issues/22308
     return Future.delayed(delay, () async {
-      final renderObject = _containerKey.currentContext?.findRenderObject();
+      final renderObject = containerKey.currentContext?.findRenderObject();
 
       if (renderObject is! RenderRepaintBoundary) {
         FlutterError.reportError(_noRenderObject());
@@ -31,7 +31,7 @@ class ScreenshotController {
   FlutterErrorDetails _noRenderObject() {
     return FlutterErrorDetails(
       exception: Exception(
-        '_containerKey.currentContext is null. '
+        'containerKey.currentContext is null. '
         'Thus we can\'t create a screenshot',
       ),
       library: 'feedback',
@@ -55,7 +55,7 @@ class Screenshot extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return RepaintBoundary(
-      key: controller._containerKey,
+      key: controller.containerKey,
       child: child,
     );
   }

--- a/feedback/test/feedback_test.dart
+++ b/feedback/test/feedback_test.dart
@@ -174,6 +174,7 @@ void main() {
       Uint8List? submittedScreenshot;
 
       final widget = BetterFeedback(
+        screenshotController: MockScreenshotController(),
         child: MyTestApp(
           onFeedback: (feedback) {
             submittedText = feedback.text;
@@ -183,9 +184,6 @@ void main() {
       );
       await tester.pumpWidget(widget);
       await tester.pumpAndSettle();
-      final feedbackWidgetState =
-          tester.state<FeedbackWidgetState>(find.byType(FeedbackWidget));
-      feedbackWidgetState.screenshotController = MockScreenshotController();
 
       // feedback is closed
       final userInputFields = find.byKey(const Key('feedback_bottom_sheet'));
@@ -219,6 +217,7 @@ void main() {
       UserFeedback? submittedFeedback;
 
       final widget = BetterFeedback(
+        screenshotController: MockScreenshotController(),
         child: MyTestApp(
           onFeedback: (feedback) {
             submittedFeedback = feedback;
@@ -239,9 +238,6 @@ void main() {
       );
       await tester.pumpWidget(widget);
       await tester.pumpAndSettle();
-      final feedbackWidgetState =
-          tester.state<FeedbackWidgetState>(find.byType(FeedbackWidget));
-      feedbackWidgetState.screenshotController = MockScreenshotController();
 
       // feedback is closed
       final userInputFields = find.byKey(const Key('feedback_bottom_sheet'));


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add the option to pass a custom ScreenshotController


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I had a use case that required custom capture logic, which let me add native screenshot support for platform views by capturing the view natively.

## :green_heart: How did you test it?
Implemented a custom ScreenshotController and passed it to BetterFeedback widget.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps


## 🔁 : Alternative Solution:

Another possible solution: is to only make the ScreenshotController key public and static without any further changes.
`static final GlobalKey containerKey = GlobalKey();`
This works since the feedback widget wraps the app, so there will always be one scrollController all the time. 
Then `feedbackBuilder` can be used to override the onSubmit logic.

