### PR TITLE
Refactor API to use strongly typed generics and push/pop style model

### DIFF
--- a/feedback/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/feedback/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/feedback/example/ios/Podfile
+++ b/feedback/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/feedback/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/feedback/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -164,7 +164,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -214,14 +214,14 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/flutter_email_sender/flutter_email_sender.framework",
-				"${BUILT_PRODUCTS_DIR}/path_provider_ios/path_provider_ios.framework",
+				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
 				"${BUILT_PRODUCTS_DIR}/share_plus/share_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_email_sender.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_ios.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios.framework",
 			);
@@ -232,10 +232,12 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -246,6 +248,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -355,7 +358,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -440,7 +443,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -489,7 +492,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/feedback/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/feedback/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/feedback/example/ios/Runner/AppDelegate.swift
+++ b/feedback/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/feedback/example/ios/Runner/Info.plist
+++ b/feedback/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/feedback/example/lib/feedback_functions.dart
+++ b/feedback/example/lib/feedback_functions.dart
@@ -1,7 +1,62 @@
 // ignore_for_file: avoid_print
 
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_email_sender/flutter_email_sender.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// Map from a string route to the underlying feedback route and it's corresponding `onSubmit`.
+/// This is just here to support the legacy `simpleFeedback` API.
+Future<void> onSubmitWithStringRoute(
+  BuildContext context,
+  String? route,
+  UserFeedback feedback,
+) {
+  return switch (route) {
+    'alert_dialog' => onSubmitAlertDialog(context, feedback),
+    'email' => onSubmitEmail(context, feedback),
+    'platform_sharing' => onSubmitPlatformSharing(context, feedback),
+    _ => throw UnsupportedError('Unsupported route: `$route`'),
+  };
+}
+
+Future<void> onSubmitEmail(BuildContext context, UserFeedback feedback) async {
+  // draft an email and send to developer
+  final screenshotFilePath = await writeImageToStorage(feedback.screenshot);
+
+  final Email email = Email(
+    body: feedback.text,
+    subject: 'App Feedback',
+    recipients: ['john.doe@flutter.dev'],
+    attachmentPaths: [screenshotFilePath],
+    isHTML: false,
+  );
+  await FlutterEmailSender.send(email);
+}
+
+Future<void> onSubmitPlatformSharing(BuildContext context, UserFeedback feedback) async {
+  final screenshotFilePath = await writeImageToStorage(feedback.screenshot);
+
+  // ignore: deprecated_member_use
+  await Share.shareFiles(
+    [screenshotFilePath],
+    text: feedback.text,
+  );
+}
+
+Future<String> writeImageToStorage(Uint8List feedbackScreenshot) async {
+  final Directory output = await getTemporaryDirectory();
+  final String screenshotFilePath = '${output.path}/feedback.png';
+  final File screenshotFile = File(screenshotFilePath);
+  await screenshotFile.writeAsBytes(feedbackScreenshot);
+  return screenshotFilePath;
+}
 
 /// Prints the given feedback to the console.
 /// This is useful for debugging purposes.
@@ -17,14 +72,9 @@ void consoleFeedbackFunction(
   }
 }
 
-/// Shows an [AlertDialog] with the given feedback.
-/// This is useful for debugging purposes.
-void alertFeedbackFunction(
-  BuildContext outerContext,
-  UserFeedback feedback,
-) {
-  showDialog<void>(
-    context: outerContext,
+Future<void> onSubmitAlertDialog(BuildContext context, UserFeedback feedback) async {
+  await showDialog<void>(
+    context: context,
     builder: (context) {
       return AlertDialog(
         title: Text(feedback.text),
@@ -51,6 +101,48 @@ void alertFeedbackFunction(
           )
         ],
       );
+    },
+  );
+}
+
+Future<void> createGitlabIssueFromFeedback(BuildContext context, UserFeedback feedback) async {
+  const projectId = 'your-gitlab-project-id';
+  const apiToken = 'your-gitlab-api-token';
+
+  final screenshotFilePath = await writeImageToStorage(feedback.screenshot);
+
+  // Upload screenshot
+  final uploadRequest = http.MultipartRequest(
+    'POST',
+    Uri.https(
+      'gitlab.com',
+      '/api/v4/projects/$projectId/uploads',
+    ),
+  )
+    ..files.add(await http.MultipartFile.fromPath(
+      'file',
+      screenshotFilePath,
+    ))
+    ..headers.putIfAbsent('PRIVATE-TOKEN', () => apiToken);
+  final uploadResponse = await uploadRequest.send();
+
+  final dynamic uploadResponseMap = jsonDecode(
+    await uploadResponse.stream.bytesToString(),
+  );
+
+  // Create issue
+  await http.post(
+    Uri.https(
+      'gitlab.com',
+      '/api/v4/projects/$projectId/issues',
+      <String, String>{
+        'title': feedback.text.padRight(80),
+        'description': '${feedback.text}\n'
+            "${uploadResponseMap["markdown"] ?? "Missing image!"}",
+      },
+    ),
+    headers: {
+      'PRIVATE-TOKEN': apiToken,
     },
   );
 }

--- a/feedback/lib/feedback.dart
+++ b/feedback/lib/feedback.dart
@@ -8,3 +8,4 @@ export 'src/feedback_mode.dart';
 export 'src/l18n/translation.dart';
 export 'src/theme/feedback_theme.dart' show FeedbackThemeData;
 export 'src/user_feedback.dart';
+export 'src/feedback_form_controller.dart';

--- a/feedback/lib/src/feedback_bottom_sheet.dart
+++ b/feedback/lib/src/feedback_bottom_sheet.dart
@@ -1,30 +1,35 @@
 // ignore_for_file: public_member_api_docs
 
 import 'package:feedback/src/better_feedback.dart';
+import 'package:feedback/src/feedback_form_controller.dart';
+import 'package:feedback/src/screenshot.dart';
 import 'package:feedback/src/theme/feedback_theme.dart';
 import 'package:feedback/src/utilities/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 
 /// Shows the text input in which the user can describe his feedback.
-class FeedbackBottomSheet extends StatelessWidget {
+class FeedbackBottomSheet<T, R> extends StatelessWidget {
   const FeedbackBottomSheet({
     super.key,
+    required this.route,
+    required this.screenshotController,
     required this.feedbackBuilder,
-    required this.onSubmit,
     required this.sheetProgress,
   });
 
-  final FeedbackBuilder feedbackBuilder;
-  final OnSubmit onSubmit;
+  final T route;
+  final ScreenshotController screenshotController;
+  final FeedbackBuilder<T, R> feedbackBuilder;
   final ValueNotifier<double> sheetProgress;
 
   @override
   Widget build(BuildContext context) {
     if (FeedbackTheme.of(context).sheetIsDraggable) {
       return DraggableScrollableActuator(
-        child: _DraggableFeedbackSheet(
+        child: _DraggableFeedbackSheet<T, R>(
+          route: route,
+          screenshotController: screenshotController,
           feedbackBuilder: feedbackBuilder,
-          onSubmit: onSubmit,
           sheetProgress: sheetProgress,
         ),
       );
@@ -43,8 +48,8 @@ class FeedbackBottomSheet extends StatelessWidget {
               return MaterialPageRoute<void>(
                 builder: (_) => feedbackBuilder(
                   context,
-                  onSubmit,
-                  null,
+                  route,
+                  FeedbackFormController<R>(screenshotController),
                 ),
               );
             },
@@ -55,23 +60,25 @@ class FeedbackBottomSheet extends StatelessWidget {
   }
 }
 
-class _DraggableFeedbackSheet extends StatefulWidget {
+class _DraggableFeedbackSheet<T, R> extends StatefulWidget {
   const _DraggableFeedbackSheet({
+    required this.route,
+    required this.screenshotController,
     required this.feedbackBuilder,
-    required this.onSubmit,
     required this.sheetProgress,
   });
 
-  final FeedbackBuilder feedbackBuilder;
-  final OnSubmit onSubmit;
+  final T route;
+  final ScreenshotController screenshotController;
+  final FeedbackBuilder<T, R> feedbackBuilder;
   final ValueNotifier<double> sheetProgress;
 
   @override
-  State<_DraggableFeedbackSheet> createState() =>
+  State<_DraggableFeedbackSheet<T, R>> createState() =>
       _DraggableFeedbackSheetState();
 }
 
-class _DraggableFeedbackSheetState extends State<_DraggableFeedbackSheet> {
+class _DraggableFeedbackSheetState<T, R> extends State<_DraggableFeedbackSheet<T, R>> {
   @override
   void initState() {
     super.initState();
@@ -111,7 +118,7 @@ class _DraggableFeedbackSheetState extends State<_DraggableFeedbackSheet> {
         ),
         Expanded(
           child: DraggableScrollableSheet(
-            controller: BetterFeedback.of(context).sheetController,
+            controller: BetterFeedback.of<T, R>(context).sheetController,
             snap: true,
             minChildSize: collapsedHeight,
             initialChildSize: collapsedHeight,
@@ -136,8 +143,8 @@ class _DraggableFeedbackSheetState extends State<_DraggableFeedbackSheet> {
                         return MaterialPageRoute<void>(
                           builder: (_) => widget.feedbackBuilder(
                             context,
-                            widget.onSubmit,
-                            scrollController,
+                            widget.route,
+                            FeedbackFormController(widget.screenshotController, scrollController),
                           ),
                         );
                       },

--- a/feedback/lib/src/feedback_builder/string_feedback.dart
+++ b/feedback/lib/src/feedback_builder/string_feedback.dart
@@ -1,15 +1,18 @@
-import 'package:feedback/src/better_feedback.dart';
-import 'package:feedback/src/l18n/translation.dart';
+import 'package:feedback/feedback.dart';
 import 'package:feedback/src/theme/feedback_theme.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Prompt the user for feedback using `StringFeedback`.
 Widget simpleFeedbackBuilder(
   BuildContext context,
-  OnSubmit onSubmit,
-  ScrollController? scrollController,
+  OnSubmit? onSubmit,
+  FeedbackFormController<UserFeedback> formController,
 ) =>
-    StringFeedback(onSubmit: onSubmit, scrollController: scrollController);
+    StringFeedback(
+      onSubmit: onSubmit,
+      formController: formController,
+    );
 
 /// A form that prompts the user for feedback with a single text field.
 /// This is the default feedback widget used by [BetterFeedback].
@@ -19,18 +22,11 @@ class StringFeedback extends StatefulWidget {
   const StringFeedback({
     super.key,
     required this.onSubmit,
-    required this.scrollController,
+    required this.formController,
   });
 
-  /// Should be called when the user taps the submit button.
-  final OnSubmit onSubmit;
-
-  /// A scroll controller that expands the sheet when it's attached to a
-  /// scrollable widget and that widget is scrolled.
-  ///
-  /// Non null if the sheet is draggable.
-  /// See: [FeedbackThemeData.sheetIsDraggable].
-  final ScrollController? scrollController;
+  final OnSubmit? onSubmit;
+  final FeedbackFormController<UserFeedback> formController;
 
   @override
   State<StringFeedback> createState() => _StringFeedbackState();
@@ -51,6 +47,10 @@ class _StringFeedbackState extends State<StringFeedback> {
     controller = TextEditingController();
   }
 
+  Future<void>? submitting;
+
+  FeedbackFormController<UserFeedback> get formController => widget.formController;
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -59,16 +59,14 @@ class _StringFeedbackState extends State<StringFeedback> {
           child: Stack(
             children: [
               ListView(
-                controller: widget.scrollController,
+                controller: formController.scrollController,
                 // Pad the top by 20 to match the corner radius if drag enabled.
-                padding: EdgeInsets.fromLTRB(
-                    16, widget.scrollController != null ? 20 : 16, 16, 0),
+                padding: EdgeInsets.fromLTRB(16, formController.scrollController != null ? 20 : 16, 16, 0),
                 children: <Widget>[
                   Text(
                     FeedbackLocalizations.of(context).feedbackDescriptionText,
                     maxLines: 2,
-                    style:
-                        FeedbackTheme.of(context).bottomSheetDescriptionStyle,
+                    style: FeedbackTheme.of(context).bottomSheetDescriptionStyle,
                   ),
                   TextField(
                     style: FeedbackTheme.of(context).bottomSheetTextInputStyle,
@@ -83,23 +81,72 @@ class _StringFeedbackState extends State<StringFeedback> {
                   ),
                 ],
               ),
-              if (widget.scrollController != null)
-                const FeedbackSheetDragHandle(),
+              if (formController.scrollController != null) const FeedbackSheetDragHandle(),
             ],
           ),
         ),
-        TextButton(
-          key: const Key('submit_feedback_button'),
-          child: Text(
-            FeedbackLocalizations.of(context).submitButtonText,
-            style: TextStyle(
-              color: FeedbackTheme.of(context).activeFeedbackModeColor,
-            ),
-          ),
-          onPressed: () => widget.onSubmit(controller.text),
+        _FeedbackSubmitButton(
+          onTap: () async {
+            final Uint8List screenshot = await formController.takeScreenshot(context);
+            if (!context.mounted) return;
+
+            final feedback = UserFeedback(text: controller.text, screenshot: screenshot);
+            await widget.onSubmit?.call(context, feedback);
+            if (!context.mounted) return;
+
+            BetterFeedback.simpleFeedbackOf(context).hide(feedback);
+          },
         ),
         const SizedBox(height: 8),
       ],
+    );
+  }
+}
+
+class _FeedbackSubmitButton extends StatefulWidget {
+  const _FeedbackSubmitButton({required this.onTap});
+
+  final AsyncCallback onTap;
+
+  @override
+  State<_FeedbackSubmitButton> createState() => _FeedbackSubmitButtonState();
+}
+
+class _FeedbackSubmitButtonState extends State<_FeedbackSubmitButton> {
+  Future<void>? submitting;
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: submitting,
+      builder: (context, snap) {
+        return TextButton(
+          key: const Key('submit_feedback_button'),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 50),
+            child: snap.connectionState == ConnectionState.waiting
+                ? Container(
+                    padding: const EdgeInsets.all(2),
+                    alignment: Alignment.center,
+                    child: CircularProgressIndicator(
+                      color: FeedbackTheme.of(context).activeFeedbackModeColor,
+                    ),
+                  )
+                : Text(
+                    FeedbackLocalizations.of(context).submitButtonText,
+                    style: TextStyle(
+                      color: FeedbackTheme.of(context).activeFeedbackModeColor,
+                    ),
+                  ),
+          ),
+          onPressed: () async {
+            setState(() {
+              submitting = widget.onTap();
+            });
+            await submitting;
+          },
+        );
+      },
     );
   }
 }

--- a/feedback/lib/src/feedback_controller.dart
+++ b/feedback/lib/src/feedback_controller.dart
@@ -1,30 +1,33 @@
+import 'dart:async';
+
 import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
 
 /// Controls the state of the feeback ui.
-class FeedbackController extends ChangeNotifier {
-  bool _isVisible = false;
+class FeedbackController<T, R> extends ChangeNotifier {
+  _FeedbackSession<T, R>? _session;
+
+  /// The current route, if any.
+  T? get currentRoute => _session?.route;
 
   /// Whether the feedback ui is currently visible.
-  bool get isVisible => _isVisible;
-
-  /// This function is called when the user submits his feedback.
-  OnFeedbackCallback? onFeedback;
+  bool get isVisible => _session != null;
 
   /// Open the feedback ui.
   /// After the user submitted his feedback [onFeedback] is called.
   /// If the user aborts the process of giving feedback, [onFeedback] is
   /// not called.
-  void show(OnFeedbackCallback onFeedback) {
-    _isVisible = true;
-    this.onFeedback = onFeedback;
+  Future<R?> show(T route) async {
+    _session = _FeedbackSession(route);
     notifyListeners();
+    return _session!.result.future;
   }
 
   /// Hides the feedback ui.
-  /// Typically, this does not need to be called by the user of this library
-  void hide() {
-    _isVisible = false;
+  void hide([R? result]) {
+    if (_session == null) return;
+    _session!.result.complete(result);
+    _session = null;
     notifyListeners();
   }
 
@@ -34,4 +37,12 @@ class FeedbackController extends ChangeNotifier {
   /// true and feedback is currently displayed.
   final DraggableScrollableController sheetController =
       DraggableScrollableController();
+}
+
+
+class _FeedbackSession<T, R> {
+  _FeedbackSession(this.route);
+
+  final T route;
+  final Completer<R?> result = Completer();
 }

--- a/feedback/lib/src/feedback_data.dart
+++ b/feedback/lib/src/feedback_data.dart
@@ -3,17 +3,17 @@
 import 'package:feedback/src/feedback_controller.dart';
 import 'package:flutter/material.dart';
 
-class FeedbackData extends InheritedWidget {
+class FeedbackData<T, R> extends InheritedWidget {
   const FeedbackData({
     super.key,
     required super.child,
     required this.controller,
   });
 
-  final FeedbackController controller;
+  final FeedbackController<T, R> controller;
 
   @override
-  bool updateShouldNotify(FeedbackData oldWidget) {
+  bool updateShouldNotify(FeedbackData<T, R> oldWidget) {
     return oldWidget.controller != controller;
   }
 }

--- a/feedback/lib/src/feedback_form_controller.dart
+++ b/feedback/lib/src/feedback_form_controller.dart
@@ -1,0 +1,27 @@
+import 'dart:typed_data';
+
+import 'package:feedback/src/screenshot.dart';
+import 'package:flutter/material.dart';
+
+class FeedbackFormController<R> {
+  const FeedbackFormController(this._screenshotController, [this.scrollController]);
+
+  final ScreenshotController _screenshotController;
+
+  final ScrollController? scrollController;
+
+  Future<Uint8List> takeScreenshot(BuildContext context, {
+    bool showKeyboard = false,
+    double pixelRatio = 3.0,
+    Duration delay = const Duration(milliseconds: 2000),
+  }) async {
+    if (!showKeyboard) {
+      FocusScope.of(context).requestFocus(FocusNode());
+    }
+    await Future<void>.delayed(delay);
+    return _screenshotController.capture(
+      pixelRatio: pixelRatio,
+      delay: Duration.zero,
+    );
+  }
+}

--- a/feedback/pubspec.yaml
+++ b/feedback/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  fpdart: ^1.1.1
 
 dev_dependencies:
   flutter_lints: ^3.0.0

--- a/feedback/test/feedback_test.dart
+++ b/feedback/test/feedback_test.dart
@@ -12,7 +12,7 @@ import 'test_app.dart';
 void main() {
   group('BetterFeedback', () {
     testWidgets('can open feedback with default settings', (tester) async {
-      final widget = BetterFeedback(
+      final widget = BetterFeedback.simpleFeedback(
         child: Builder(
           builder: (context) {
             return const MyTestApp();
@@ -41,7 +41,7 @@ void main() {
     });
 
     testWidgets('can open feedback in drawing mode', (tester) async {
-      final widget = BetterFeedback(
+      final widget = BetterFeedback.simpleFeedback(
         mode: FeedbackMode.draw,
         child: Builder(
           builder: (context) {
@@ -71,7 +71,7 @@ void main() {
     });
 
     testWidgets('can open feedback in navigation mode', (tester) async {
-      final widget = BetterFeedback(
+      final widget = BetterFeedback.simpleFeedback(
         mode: FeedbackMode.navigate,
         child: Builder(
           builder: (context) {


### PR DESCRIPTION
## :scroll: Description
1. Better feedback now has a generic type for an input object (passed into `show`) and an output object (passed into hide, returned from show) that enforces end to end type safety
2. Legacy `simpleFeedback` system was moved to a static method (necessary to set the default type params)
3. `simpleFeedback` now runs the `onSubmit` callback before closing the feedback flow
4. Custom feedback forms are passed a `FeedbakcFormController` that exposes the screenshot and scroll controllers
5. Custom feedback forms are expected to take the screenshot, construct the feedback object, and call `hide` themselves

## :bulb: Motivation and Context

There are three core goals with this rewrite:
1. Maintain a backwards compatible API for users that don't want the new features/flexibility
2. Provide end to end type safety for custom feedback forms
3. Allow for custom feedback flows to get the screenshot from within the form so they can run async submit logic BEFORE closing the feedback form

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
