### PR TITLE
Add link to feedback_github package

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ understand.
 Depending on your use case there are wide variety of solutions.
 These are a couple suggestions:
 
-| Plugin                         | Package                          |
-|--------------------------------|--------------------------------|
-| GitLab Issue                   | [feedback_gitlab](https://pub.dev/packages/feedback_gitlab) |
-| Sentry User Feedback           | [feedback_sentry](https://pub.dev/packages/feedback_sentry) |
-| GitHub Issue                   | [feedback_github](https://pub.dev/packages/feedback_github) |
+| Plugin                         | Package                                                     | Notes                             |
+|--------------------------------|-------------------------------------------------------------|-----------------------------------|
+| GitLab Issue                   | [feedback_gitlab](https://pub.dev/packages/feedback_gitlab) |                                   |
+| Sentry User Feedback           | [feedback_sentry](https://pub.dev/packages/feedback_sentry) |                                   |
+| GitHub Issue                   | [feedback_github](https://pub.dev/packages/feedback_github) | Uses Firebase Storage for images  |
 
 
 | Target                         | Notes                          |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These are a couple suggestions:
 |--------------------------------|--------------------------------|
 | GitLab Issue                   | [feedback_gitlab](https://pub.dev/packages/feedback_gitlab) |
 | Sentry User Feedback           | [feedback_sentry](https://pub.dev/packages/feedback_sentry) |
+| GitHub Issue                   | [feedback_github](https://pub.dev/packages/feedback_github) |
 
 
 | Target                         | Notes                          |


### PR DESCRIPTION
## :scroll: Description
I created a variant to upload feedback as github issues, storing images in a firebase storage bucket
I only added the link to the package in readme : https://pub.dev/packages/feedback_github
The github repo : https://github.com/tempo-riz/feedback_github
