### PR TITLE
fix(web): prevent Focus exception after feedback submission and window restore

### DIFF
--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -353,6 +353,9 @@ class FeedbackWidgetState extends State<FeedbackWidget>
   }
 
   static void _hideKeyboard(BuildContext context) {
+    if (kIsWeb) { // No keyboard to hide in web
+      return;
+    }
     FocusScope.of(context).requestFocus(FocusNode());
   }
 }

--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -353,10 +353,11 @@ class FeedbackWidgetState extends State<FeedbackWidget>
   }
 
   static void _hideKeyboard(BuildContext context) {
-    if (kIsWeb) { // No keyboard to hide in web
-      return;
+    final currentFocus = FocusScope.of(context);
+
+    if (!currentFocus.hasPrimaryFocus && currentFocus.focusedChild != null) {
+      currentFocus.unfocus();
     }
-    FocusScope.of(context).requestFocus(FocusNode());
   }
 }
 


### PR DESCRIPTION
This hotfix addresses a Focus exception that occurs on the Web platform when a user submits feedback and then hides/restores the browser window. The issue stems from a focus context being accessed before it's properly attached.

## :scroll: Description
This fix wraps focus-related logic to prevent execution if the context is not available, avoiding a crash caused by premature access to focus traversal state. This issue was reproducible only on the Web after toggling browser window visibility post-feedback submission.

Sample of crash:  
`Exception:
DartError: Assertion failed: file:///home/user/snap/flutter/common/flutter/packages/flutter/lib/src/widgets/focus_manager.dart:854:7
context != null
"Tried to get the bounds of a focus node that didn't have its context set yet.\nThe context needs to be set before trying to evaluate traversal policies. Setting the context is typically done with the attach method."
dart-sdk/lib/internal/js_dev_runtime/private/ddc_runtime/errors.dart 307:3     throw
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 117:39               assertFailed
packages/flutter/src/widgets/focus_manager.dart 854:15                          get rect
packages/flutter/src/widgets/focus_traversal.dart 1245:18                       new
packages/flutter/src/widgets/focus_traversal.dart 1532:49                       <fn>
packages/flutter/src/widgets/focus_traversal.dart 1531:69                       sortDescendants
packages/flutter/src/widgets/focus_traversal.dart 500:21                        _sortAllDescendants
packages/flutter/src/widgets/focus_traversal.dart 322:9                         [_findInitialFocus]
packages/flutter/src/widgets/focus_traversal.dart 283:12                        findFirstFocus
packages/flutter/src/widgets/view.dart 254:33                                   didChangeViewFocus
packages/flutter/src/widgets/binding.dart 1038:15                               handleViewFocusChanged
lib/_engine/engine/platform_dispatcher.dart 1362:5                              invoke1
lib/_engine/engine/platform_dispatcher.dart 239:5                               invokeOnViewFocusChange
lib/_engine/engine/platform_dispatcher/view_focus_binding.dart 122:23           [_handleFocusChange]
lib/_engine/engine/platform_dispatcher/view_focus_binding.dart 63:5             <fn>
dart-sdk/lib/_internal/js_dev_runtime/patch/js_allow_interop_patch.dart 224:27  _callDartFunctionFast1

`


## :bulb: Motivation and Context
This change is required to improve stability on the Web and prevent a runtime exception during user feedback flow.
Fixes a user experience bug reported when switching between browser tabs or minimizing and restoring the window after sending feedback.


## :green_heart: How did you test it?
Steps to reproduce:
Step 1. Run Web app in debug mode
Step 2. Press Submit button, got Success response
Step 3. Minimize Chrome window
Step 4. Restore Chrome window
Step n. Repeat Steps 1-4 until get Exception


## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes