### PR TITLE
Add Bangla (bn) Localization Support

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -336,6 +336,24 @@ class EsFeedbackLocalizations extends FeedbackLocalizations {
   String get navigate => 'Navegar';
 }
 
+/// Default bangla localization
+class BnFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [BnFeedbackLocalizations]
+  const BnFeedbackLocalizations();
+
+  @override
+  String get submitButtonText => 'জমা দিন';
+
+  @override
+  String get feedbackDescriptionText => 'সমস্যার বিস্তারিত লিখুন';
+
+  @override
+  String get draw => 'আঁকুন';
+
+  @override
+  String get navigate => 'নেভিগেট';
+}
+
 // coverage:ignore-end
 
 /// This is a localization delegate, which includes all of the localizations
@@ -368,6 +386,7 @@ class GlobalFeedbackLocalizationsDelegate
     const Locale('bg'): const BgFeedbackLocalizations(),
     const Locale('es'): const EsFeedbackLocalizations(),
     const Locale('fa'): const FaFeedbackLocalizations(),
+    const Locale('bn'): const BnFeedbackLocalizations(),
   };
 
   /// The default locale to use. Note that this locale should ALWAYS be


### PR DESCRIPTION
## \:bulb: Motivation and Context

The `feedback` package did not support Bangla, which is needed for apps like Charge.AI serving Bangladeshi users.

## \:green\_heart: How did you test it?

* Manually tested in a demo Flutter app using `BetterFeedback` widget.
* Switched device/app locale to `bn` and verified translated text.

## \:pencil: Checklist

* [x] I reviewed submitted code
* [x] I added tests to verify changes (manual for now)
* [x] I updated the docs if needed (`README.md` for new locale mention)
* [x] All tests passing (if applicable)
* [x] No breaking changes

---

## \:crystal\_ball: Next steps

* Consider adding support for other RTL languages like Urdu.
* Improve UI adaptability for translated text with longer phrases.