### PR TITLE
Add showModeButtons option to control visibility of mode switch buttons in BetterFeedback

### DIFF
--- a/feedback/example/lib/main.dart
+++ b/feedback/example/lib/main.dart
@@ -41,6 +41,7 @@ class _MyAppState extends State<MyApp> {
                 scrollController: scrollController,
               )
           : null,
+      showModeButtons: true,
       theme: FeedbackThemeData(
         background: Colors.grey,
         feedbackSheetColor: Colors.grey[50]!,

--- a/feedback/lib/src/better_feedback.dart
+++ b/feedback/lib/src/better_feedback.dart
@@ -112,6 +112,7 @@ class BetterFeedback extends StatefulWidget {
     this.localeOverride,
     this.mode = FeedbackMode.draw,
     this.pixelRatio = 3.0,
+    this.showModeButtons = true,
   }) : assert(
           pixelRatio > 0,
           'pixelRatio needs to be larger than 0',
@@ -176,6 +177,11 @@ class BetterFeedback extends StatefulWidget {
   /// for information on the underlying implementation.
   final double pixelRatio;
 
+  /// Displays the mode switch buttons in the feedback UI.
+  ///
+  /// If set to `false`, the mode can only be changed through the `mode` property.
+  final bool showModeButtons;
+
   /// Call `BetterFeedback.of(context)` to get an
   /// instance of [FeedbackData] on which you can call `.show()` or `.hide()`
   /// to enable or disable the feedback view.
@@ -233,6 +239,7 @@ class _BetterFeedbackState extends State<BetterFeedback> {
                 isFeedbackVisible: controller.isVisible,
                 drawColors: FeedbackTheme.of(context).drawColors,
                 mode: widget.mode,
+                showModeButtons: widget.showModeButtons,
                 pixelRatio: widget.pixelRatio,
                 feedbackBuilder:
                     widget.feedbackBuilder ?? simpleFeedbackBuilder,

--- a/feedback/lib/src/controls_column.dart
+++ b/feedback/lib/src/controls_column.dart
@@ -17,6 +17,7 @@ class ControlsColumn extends StatelessWidget {
     required this.onUndo,
     required this.onControlModeChanged,
     required this.onCloseFeedback,
+    required this.showModeButtons,
     required this.onClearDrawing,
     required this.colors,
   })  : assert(
@@ -32,6 +33,7 @@ class ControlsColumn extends StatelessWidget {
   final VoidCallback onClearDrawing;
   final List<Color> colors;
   final Color activeColor;
+  final bool showModeButtons;
   final FeedbackMode mode;
 
   @override
@@ -55,32 +57,34 @@ class ControlsColumn extends StatelessWidget {
             onPressed: onCloseFeedback,
           ),
           _ColumnDivider(),
-          RotatedBox(
-            quarterTurns: 1,
-            child: MaterialButton(
-              key: const ValueKey<String>('navigate_button'),
-              onPressed: isNavigatingActive
-                  ? null
-                  : () => onControlModeChanged(FeedbackMode.navigate),
-              disabledTextColor:
-                  FeedbackTheme.of(context).activeFeedbackModeColor,
-              child: Text(FeedbackLocalizations.of(context).navigate),
+          if (showModeButtons) ...[
+            RotatedBox(
+              quarterTurns: 1,
+              child: MaterialButton(
+                key: const ValueKey<String>('navigate_button'),
+                onPressed: isNavigatingActive
+                    ? null
+                    : () => onControlModeChanged(FeedbackMode.navigate),
+                disabledTextColor:
+                    FeedbackTheme.of(context).activeFeedbackModeColor,
+                child: Text(FeedbackLocalizations.of(context).navigate),
+              ),
             ),
-          ),
-          _ColumnDivider(),
-          RotatedBox(
-            quarterTurns: 1,
-            child: MaterialButton(
-              key: const ValueKey<String>('draw_button'),
-              minWidth: 20,
-              onPressed: isNavigatingActive
-                  ? () => onControlModeChanged(FeedbackMode.draw)
-                  : null,
-              disabledTextColor:
-                  FeedbackTheme.of(context).activeFeedbackModeColor,
-              child: Text(FeedbackLocalizations.of(context).draw),
+            _ColumnDivider(),
+            RotatedBox(
+              quarterTurns: 1,
+              child: MaterialButton(
+                key: const ValueKey<String>('draw_button'),
+                minWidth: 20,
+                onPressed: isNavigatingActive
+                    ? () => onControlModeChanged(FeedbackMode.draw)
+                    : null,
+                disabledTextColor:
+                    FeedbackTheme.of(context).activeFeedbackModeColor,
+                child: Text(FeedbackLocalizations.of(context).draw),
+              ),
             ),
-          ),
+          ],
           IconButton(
             key: const ValueKey<String>('undo_button'),
             icon: const Icon(Icons.undo),

--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -24,6 +24,7 @@ class FeedbackWidget extends StatefulWidget {
     required this.child,
     required this.isFeedbackVisible,
     required this.drawColors,
+    required this.showModeButtons,
     required this.mode,
     required this.pixelRatio,
     required this.feedbackBuilder,
@@ -35,6 +36,7 @@ class FeedbackWidget extends StatefulWidget {
         );
 
   final bool isFeedbackVisible;
+  final bool showModeButtons;
   final FeedbackMode mode;
   final double pixelRatio;
   final Widget child;
@@ -219,6 +221,7 @@ class FeedbackWidgetState extends State<FeedbackWidget>
                               child: ControlsColumn(
                                 mode: mode,
                                 activeColor: painterController.drawColor,
+                                showModeButtons: widget.showModeButtons,
                                 colors: widget.drawColors,
                                 onColorChanged: (color) {
                                   setState(() {

--- a/feedback/test/controls_column_test.dart
+++ b/feedback/test/controls_column_test.dart
@@ -8,6 +8,7 @@ void main() {
   Widget create({
     Color? activeColor,
     FeedbackMode? mode,
+    bool? showNavigateButton,
     ValueChanged<Color>? onColorChanged,
     VoidCallback? onUndo,
     ValueChanged<FeedbackMode>? onControlModeChanged,
@@ -19,6 +20,7 @@ void main() {
       child: ControlsColumn(
         activeColor: activeColor ?? Colors.red,
         mode: mode ?? FeedbackMode.draw,
+        showModeButtons: showNavigateButton ?? true,
         colors:
             colors ?? [Colors.red, Colors.green, Colors.blue, Colors.yellow],
         onClearDrawing: onClearDrawing ?? () {},


### PR DESCRIPTION
## :scroll: Description
This PR introduces a new `showModeButtons` property to the `BetterFeedback` widget, allowing developers to control whether mode switch buttons (e.g., navigate, draw) are visible in the feedback UI.  

When set to `false`, the mode cannot be changed by the user via UI buttons and will only use the mode provided through the `mode` property.

## :bulb: Motivation and Context
Previously, the feedback UI always displayed the mode switch buttons, which might not be desirable in certain use cases — for example, when you want to lock the user into a specific mode without showing extra UI elements.  
This change provides more flexibility and cleaner UI control.

## :green_heart: How did you test it?
- Manually tested with `showModeButtons` set to both `true` and `false` in a sample app.
- Verified that when `false`, only the `mode` property determines the feedback mode.
- Verified that when `true`, the UI displays both mode switch buttons as expected.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs for the new property
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- Release a new version of the package including this feature.
- Update the README with usage examples for `showModeButtons`.
