### PR TITLE
Add customizable background color for feedback action menu

### DIFF
--- a/feedback/lib/src/controls_column.dart
+++ b/feedback/lib/src/controls_column.dart
@@ -54,7 +54,8 @@ class ControlsColumn extends StatelessWidget {
         children: <Widget>[
           IconButton(
             key: const ValueKey<String>('close_controls_column'),
-            icon: const Icon(Icons.close),
+            icon: Icon(Icons.close,
+                color: FeedbackTheme.of(context).feedbackMenuForegroundColor),
             onPressed: onCloseFeedback,
           ),
           _ColumnDivider(),
@@ -86,12 +87,14 @@ class ControlsColumn extends StatelessWidget {
           ),
           IconButton(
             key: const ValueKey<String>('undo_button'),
-            icon: const Icon(Icons.undo),
+            icon: Icon(Icons.undo,
+                color: FeedbackTheme.of(context).feedbackMenuForegroundColor),
             onPressed: isNavigatingActive ? null : onUndo,
           ),
           IconButton(
             key: const ValueKey<String>('clear_button'),
-            icon: const Icon(Icons.delete),
+            icon: Icon(Icons.delete,
+                color: FeedbackTheme.of(context).feedbackMenuForegroundColor),
             onPressed: isNavigatingActive ? null : onClearDrawing,
           ),
           for (final color in colors)

--- a/feedback/lib/src/controls_column.dart
+++ b/feedback/lib/src/controls_column.dart
@@ -13,6 +13,7 @@ class ControlsColumn extends StatelessWidget {
     super.key,
     required this.mode,
     required this.activeColor,
+    required this.backgroundColor,
     required this.onColorChanged,
     required this.onUndo,
     required this.onControlModeChanged,
@@ -32,12 +33,14 @@ class ControlsColumn extends StatelessWidget {
   final VoidCallback onClearDrawing;
   final List<Color> colors;
   final Color activeColor;
+  final Color backgroundColor;
   final FeedbackMode mode;
 
   @override
   Widget build(BuildContext context) {
     final isNavigatingActive = FeedbackMode.navigate == mode;
     return Card(
+      color: backgroundColor,
       margin: EdgeInsets.zero,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(

--- a/feedback/lib/src/feedback_widget.dart
+++ b/feedback/lib/src/feedback_widget.dart
@@ -217,6 +217,8 @@ class FeedbackWidgetState extends State<FeedbackWidget>
                               progress: sheetProgress,
                               minScale: .7,
                               child: ControlsColumn(
+                                backgroundColor: FeedbackTheme.of(context)
+                                    .feedbackMenuBackgroundColor,
                                 mode: mode,
                                 activeColor: painterController.drawColor,
                                 colors: widget.drawColors,

--- a/feedback/lib/src/theme/feedback_theme.dart
+++ b/feedback/lib/src/theme/feedback_theme.dart
@@ -35,6 +35,7 @@ class FeedbackThemeData {
   FeedbackThemeData(
       {this.background = Colors.grey,
       this.feedbackSheetColor = _lightGrey,
+      this.feedbackMenuBackgroundColor = _lightGrey,
       this.feedbackSheetHeight = .25,
       this.activeFeedbackModeColor = _blue,
       this.drawColors = _defaultDrawColors,
@@ -96,6 +97,10 @@ class FeedbackThemeData {
   /// The background color of the bottom sheet in which the user can input
   /// his feedback and thoughts.
   final Color feedbackSheetColor;
+
+  /// The background color of the column containing the action buttons
+  /// in the feedback menu.
+  final Color feedbackMenuBackgroundColor;
 
   /// The height of the bottom sheet as a fraction of the screen height.
   ///

--- a/feedback/lib/src/theme/feedback_theme.dart
+++ b/feedback/lib/src/theme/feedback_theme.dart
@@ -36,6 +36,7 @@ class FeedbackThemeData {
       {this.background = Colors.grey,
       this.feedbackSheetColor = _lightGrey,
       this.feedbackMenuBackgroundColor = _lightGrey,
+      this.feedbackMenuForegroundColor = Colors.black,
       this.feedbackSheetHeight = .25,
       this.activeFeedbackModeColor = _blue,
       this.drawColors = _defaultDrawColors,
@@ -70,6 +71,8 @@ class FeedbackThemeData {
         background: Colors.grey.shade700,
         dragHandleColor: Colors.white38,
         feedbackSheetColor: _darkGrey,
+        feedbackMenuBackgroundColor: _darkGrey,
+        feedbackMenuForegroundColor: Colors.white,
         bottomSheetDescriptionStyle: const TextStyle(
           color: Colors.white,
         ),
@@ -83,6 +86,8 @@ class FeedbackThemeData {
         background: Colors.grey,
         dragHandleColor: Colors.black26,
         feedbackSheetColor: _lightGrey,
+        feedbackMenuBackgroundColor: _lightGrey,
+        feedbackMenuForegroundColor: Colors.black,
         bottomSheetDescriptionStyle: _defaultBottomSheetDescriptionStyle,
         sheetIsDraggable: sheetIsDraggable,
         brightness: Brightness.light,
@@ -101,6 +106,10 @@ class FeedbackThemeData {
   /// The background color of the column containing the action buttons
   /// in the feedback menu.
   final Color feedbackMenuBackgroundColor;
+
+  /// The foreground color of the column containing the action buttons (Trash, Undo, ModeButtons)
+  /// in the feedback menu.
+  final Color feedbackMenuForegroundColor;
 
   /// The height of the bottom sheet as a fraction of the screen height.
   ///

--- a/feedback/test/controls_column_test.dart
+++ b/feedback/test/controls_column_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 void main() {
   Widget create({
     Color? activeColor,
+    Color? backgroundColor,
     FeedbackMode? mode,
     ValueChanged<Color>? onColorChanged,
     VoidCallback? onUndo,
@@ -18,6 +19,7 @@ void main() {
     return FeedbackLocalization(
       child: ControlsColumn(
         activeColor: activeColor ?? Colors.red,
+        backgroundColor: backgroundColor ?? Colors.grey,
         mode: mode ?? FeedbackMode.draw,
         colors:
             colors ?? [Colors.red, Colors.green, Colors.blue, Colors.yellow],


### PR DESCRIPTION
## :scroll: Description
`feedbackMenuBackgroundColor` to allow customizing the background color of the column containing action buttons in the feedback menu.
`feedbackMenuForegroundColor` to allow customizing the text and icon colors of the action buttons in the feedback menu.

## :bulb: Motivation and Context
Previously, the feedback menu had fixed background and foreground colors for the action buttons column, which limited customization. This change provides flexibility for theming and improves visual consistency and accessibility across apps using the package.

## :green_heart: How did you test it?
Tested locally by setting `feedbackMenuBackgroundColor` and `feedbackMenuForegroundColor` to different colors.
Verified that the action buttons column background and foreground update correctly without affecting other parts of the menu.

## :pencil: Checklist
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- Consider adding more theming options for other parts of the feedback menu.
