### PR TITLE
Add copyWith method and make UserFeedback constructor const

### DIFF
--- a/feedback/lib/src/user_feedback.dart
+++ b/feedback/lib/src/user_feedback.dart
@@ -5,7 +5,7 @@ import 'package:feedback/src/better_feedback.dart';
 class UserFeedback {
   /// Creates an [UserFeedback].
   /// Typically never used by a user of this library.
-  UserFeedback({
+  const UserFeedback({
     required this.text,
     required this.screenshot,
     this.extra,
@@ -22,4 +22,21 @@ class UserFeedback {
   /// When using a custom [BetterFeedback.feedbackBuilder] this can be used
   /// to supply additional information.
   final Map<String, dynamic>? extra;
+
+  /// Creates a copy of this [UserFeedback] with the given fields replaced
+  /// by new values.
+  ///
+  /// Any parameter that is omitted will default to the value of the
+  /// corresponding field in this instance.
+  UserFeedback copyWith({
+    String? text,
+    Uint8List? screenshot,
+    Map<String, dynamic>? extra,
+  }) {
+    return UserFeedback(
+      text: text ?? this.text,
+      screenshot: screenshot ?? this.screenshot,
+      extra: extra ?? this.extra,
+    );
+  }
 }


### PR DESCRIPTION
Added a copyWith method to UserFeedback class for creating modified copies of instances.

## :scroll: Description
This change adds a `copyWith` method to the `UserFeedback` class, allowing
creation of modified copies of an existing instance.

The constructor was also marked as `const`, enabling compile-time
instantiation when possible. Both changes are additive and backward-compatible.


## :bulb: Motivation and Context
`UserFeedback` is effectively an immutable data container. Adding a `copyWith`
method makes it easier to derive modified versions of an existing instance
without manually copying all fields.

This follows common Flutter and Dart patterns for immutable model classes and
improves ergonomics when extending or transforming feedback data.


## :green_heart: How did you test it?
The change is purely additive and does not affect existing behavior.

The `copyWith` method was verified manually to ensure:
- Provided parameters correctly override existing values
- Omitted parameters retain their original values


## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
None. This change is self-contained and does not require follow-up work.
