### PR TITLE
Add Tamil localization

### DIFF
--- a/feedback/lib/src/l18n/translation.dart
+++ b/feedback/lib/src/l18n/translation.dart
@@ -372,6 +372,24 @@ class HeFeedbackLocalizations extends FeedbackLocalizations {
   String get navigate => 'ניווט';
 }
 
+/// Default tamil localization
+class TaFeedbackLocalizations extends FeedbackLocalizations {
+  /// Creates a [TaFeedbackLocalizations].
+  const TaFeedbackLocalizations();
+
+  @override
+  String get submitButtonText => 'சமர்ப்பி';
+
+  @override
+  String get feedbackDescriptionText => 'என்ன பிரச்சனை?';
+
+  @override
+  String get draw => 'வரை';
+
+  @override
+  String get navigate => 'வழிசெலுத்து';
+}
+
 // coverage:ignore-end
 
 /// This is a localization delegate, which includes all of the localizations
@@ -406,6 +424,7 @@ class GlobalFeedbackLocalizationsDelegate
     const Locale('fa'): const FaFeedbackLocalizations(),
     const Locale('bn'): const BnFeedbackLocalizations(),
     const Locale('he'): const HeFeedbackLocalizations(),
+    const Locale('ta'): const TaFeedbackLocalizations(),
   };
 
   /// The default locale to use. Note that this locale should ALWAYS be


### PR DESCRIPTION
## :scroll: Description
This PR adds Tamil (`ta`) localization support to the `feedback` package.


## :bulb: Motivation and Context
Adding Tamil translations increases accessibility for Tamil-speaking users.


## :green_heart: How did you test it?
- Configured the example application to run with `localeOverride: const Locale('ta')`.
- Compiled and launched the example app on an Android device to manually verify that the text labels ("சமர்ப்பி", "என்ன பிரச்சனை?", "வரை", "வழிசெலுத்து") are translated and rendered correctly.


## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated the docs if needed
- [x] All tests passing
- [x] No breaking changes
